### PR TITLE
Added View Remaining Budget Command

### DIFF
--- a/src/main/java/wallet/logic/command/ViewCommand.java
+++ b/src/main/java/wallet/logic/command/ViewCommand.java
@@ -20,7 +20,7 @@ public class ViewCommand extends Command {
     public static final String MESSAGE_EMPTY_LOANS = "There are no loans";
     public static final String MESSAGE_EMPTY_EXPENSES = "There are no expenses";
     public static final String MESSAGE_EMPTY_BUDGET = "There is no budget set for ";
-    public static final String MESSAGE_VIEW_BUDGET = "This is the budget for ";
+    public static final String MESSAGE_VIEW_BUDGET = "This is the budget left for ";
     public static final String MESSAGE_USAGE = "Error in format for command."
             + "\nExample: " + COMMAND_WORD + " all"
             + "\nExample: " + COMMAND_WORD + " 01/01/2019"

--- a/src/main/java/wallet/logic/command/ViewCommand.java
+++ b/src/main/java/wallet/logic/command/ViewCommand.java
@@ -1,10 +1,12 @@
 package wallet.logic.command;
 
 import wallet.model.Wallet;
+import wallet.model.record.Budget;
 import wallet.model.record.Expense;
 import wallet.model.record.Loan;
 import wallet.ui.Ui;
 
+import java.text.DateFormatSymbols;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -17,59 +19,83 @@ public class ViewCommand extends Command {
     public static final String MESSAGE_VIEW_LOANS_SPECIFIED = "Here are your loans for ";
     public static final String MESSAGE_EMPTY_LOANS = "There are no loans";
     public static final String MESSAGE_EMPTY_EXPENSES = "There are no expenses";
+    public static final String MESSAGE_EMPTY_BUDGET = "There is no budget set for ";
+    public static final String MESSAGE_VIEW_BUDGET = "This is the budget for ";
     public static final String MESSAGE_USAGE = "Error in format for command."
             + "\nExample: " + COMMAND_WORD + " all"
-            + "\nExample: " + COMMAND_WORD + " 01/01/2019";
+            + "\nExample: " + COMMAND_WORD + " 01/01/2019"
+            + "\nExample: " + COMMAND_WORD + " budget 01/2019";
 
-    private final String type;
+    private String[] type;
 
-    public ViewCommand(String type) {
+    public ViewCommand(String... type) {
         this.type = type;
     }
 
     @Override
     public boolean execute(Wallet wallet) {
         Ui ui = new Ui();
-        if (type.equals("all")) {
-            if (wallet.getExpenseList().getSize() != 0) {
-                System.out.println(MESSAGE_VIEW_EXPENSES);
+        if (type.length == 1) {
+            if (type.equals("all")) {
+                if (wallet.getExpenseList().getSize() != 0) {
+                    System.out.println(MESSAGE_VIEW_EXPENSES);
+                    for (Expense e : wallet.getExpenseList().getExpenseList()) {
+                        System.out.println(e.toString());
+                    }
+                    ui.printLine();
+                } else {
+                    System.out.println(MESSAGE_EMPTY_EXPENSES);
+                }
+
+                if (wallet.getLoanList().getSize() != 0) {
+                    System.out.println(MESSAGE_VIEW_LOANS);
+                    ui.printLine();
+                } else {
+                    System.out.println(MESSAGE_EMPTY_LOANS);
+                }
+                return false;
+            }
+
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+            LocalDate date = LocalDate.parse(type[0].trim(), formatter);
+
+            if (!date.equals(null)) {
+                System.out.println(date);
+                ui.printLine();
+                System.out.println(MESSAGE_VIEW_EXPENSES_SPECIFIED + date);
                 for (Expense e : wallet.getExpenseList().getExpenseList()) {
-                    System.out.println(e.toString());
+                    if (e.getDate().equals(date)) {
+                        System.out.println(e.toString());
+                    }
                 }
                 ui.printLine();
-            } else {
-                System.out.println(MESSAGE_EMPTY_EXPENSES);
-            }
 
-            if (wallet.getLoanList().getSize() != 0) {
-                System.out.println(MESSAGE_VIEW_LOANS);
-                ui.printLine();
-            } else {
-                System.out.println(MESSAGE_EMPTY_LOANS);
-            }
-            return false;
-        }
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
-        LocalDate date = LocalDate.parse(type.trim(), formatter);
-
-        if (!date.equals(null)) {
-            System.out.println(date);
-            ui.printLine();
-            System.out.println(MESSAGE_VIEW_EXPENSES_SPECIFIED + date);
-            for (Expense e : wallet.getExpenseList().getExpenseList()) {
-                if (e.getDate().equals(date)) {
-                    System.out.println(e.toString());
+                System.out.println(MESSAGE_VIEW_LOANS_SPECIFIED + date);
+                for (Loan l : wallet.getLoanList().getLoanList()) {
+                    if (l.getDate().equals(date)) {
+                        System.out.println(l.toString());
+                    }
                 }
             }
-            ui.printLine();
+        } else if (type.length == 2) {
 
-            System.out.println(MESSAGE_VIEW_LOANS_SPECIFIED + date);
-            for (Loan l : wallet.getLoanList().getLoanList()) {
-                if (l.getDate().equals(date)) {
-                    System.out.println(l.toString());
+            if (type[0].equals("budget")) {
+                String[] monthYear = type[1].split("/", 2);
+                int month = Integer.parseInt(monthYear[0].trim());
+                int year = Integer.parseInt(monthYear[1].trim());
+
+                for (Budget b : wallet.getBudgetList().getBudgetList()) {
+                    if (b.getMonth() == month && b.getYear() == year) {
+                        System.out.println(MESSAGE_VIEW_BUDGET
+                                + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
+                        System.out.println("$" + b.getAmount());
+                        return false;
+                    }
                 }
-            }
 
+                System.out.println(MESSAGE_EMPTY_BUDGET
+                        +  new DateFormatSymbols().getMonths()[month - 1] + " " + year);
+            }
         } else {
             System.out.println(MESSAGE_USAGE);
         }

--- a/src/main/java/wallet/logic/parser/ViewCommandParser.java
+++ b/src/main/java/wallet/logic/parser/ViewCommandParser.java
@@ -7,7 +7,8 @@ public class ViewCommandParser implements Parser<ViewCommand> {
     @Override
     public ViewCommand parse(String input) {
         if (input != "") {
-            return new ViewCommand(input);
+            String[] arguments = input.split(" ");
+            return new ViewCommand(arguments);
         }
         return null;
     }


### PR DESCRIPTION
Added the option for users to view remaining budget for their specified month/year under **VIEW** command. (Therefore note to add this in UG/DG)

Under view command, simply type the following:
"view budget 01/2019"
This will show the remaining budget of January 2019, provided it exists.
If budget does not exist, a message will be shown to show that record cannot be found.