### PR TITLE
Currency Conversion #1

### DIFF
--- a/src/main/java/wallet/logic/LogicManager.java
+++ b/src/main/java/wallet/logic/LogicManager.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
  */
 public class LogicManager {
     public static final String MESSAGE_ERROR_COMMAND = "An error encountered while executing command.";
-    private static CurrencyStorage currencyStorage;
+    private CurrencyStorage currencyStorage;
     private static StorageManager storageManager;
     private ParserManager parserManager;
     private static Wallet wallet;

--- a/src/main/java/wallet/logic/LogicManager.java
+++ b/src/main/java/wallet/logic/LogicManager.java
@@ -6,11 +6,13 @@ import wallet.logic.parser.ParserManager;
 import wallet.model.Wallet;
 import wallet.model.WalletList;
 import wallet.model.contact.ContactList;
+import wallet.model.currency.CurrencyList;
 import wallet.model.record.BudgetList;
 import wallet.model.record.ExpenseList;
 import wallet.model.record.LoanList;
 import wallet.model.record.RecordList;
 import wallet.reminder.Reminder;
+import wallet.storage.CurrencyStorage;
 import wallet.storage.StorageManager;
 
 import java.util.ArrayList;
@@ -23,6 +25,7 @@ import java.util.ArrayList;
  */
 public class LogicManager {
     public static final String MESSAGE_ERROR_COMMAND = "An error encountered while executing command.";
+    private static CurrencyStorage currencyStorage;
     private static StorageManager storageManager;
     private ParserManager parserManager;
     private static Wallet wallet;
@@ -35,8 +38,11 @@ public class LogicManager {
      * Constructs a LogicManager object.
      */
     public LogicManager() {
+        this.currencyStorage = new CurrencyStorage();
         this.storageManager = new StorageManager();
-        this.wallet = new Wallet(new BudgetList(storageManager.loadBudget()), new RecordList(),
+        this.wallet = new Wallet(new CurrencyList(currencyStorage.loadFile()),
+                new BudgetList(storageManager.loadBudget()),
+                new RecordList(),
                 new ExpenseList(storageManager.loadExpense()),
                 new ContactList(storageManager.loadContact()),
                 new LoanList(storageManager.loadLoan()));
@@ -58,7 +64,9 @@ public class LogicManager {
         boolean isExit = false;
         StorageManager newStorageManager = new StorageManager();
 
-        Wallet newWallet = new Wallet(new BudgetList(newStorageManager.loadBudget()), new RecordList(),
+        Wallet newWallet = new Wallet(new CurrencyList(currencyStorage.loadFile()),
+                new BudgetList(newStorageManager.loadBudget()),
+                new RecordList(),
                 new ExpenseList(newStorageManager.loadExpense()),
                 new ContactList(newStorageManager.loadContact()),
                 new LoanList(newStorageManager.loadLoan()));

--- a/src/main/java/wallet/logic/command/CurrencyCommand.java
+++ b/src/main/java/wallet/logic/command/CurrencyCommand.java
@@ -1,0 +1,35 @@
+//@@author matthewng1996
+
+package wallet.logic.command;
+
+import wallet.model.Wallet;
+import wallet.thread.CurrencyThread;
+
+public class CurrencyCommand extends Command {
+    public static final String COMMAND_WORD = "currency";
+
+    public static final String MESSAGE_NO_CURRENCY = "There is no such currency found for the conversion to ";
+    public static final String MESSAGE_SUCCESSFUL_CONVERSION = "Your currency is converted to the country of ";
+    public static final String MESSAGE_ADDING_CURRENCY =
+            "You can add or modify your own currency conversion in /currency.txt";
+    public static final String MESSAGE_USAGE = "Error in format for command."
+            + "\nExample: " + COMMAND_WORD + " singapore"
+            + "\nExample: " + COMMAND_WORD + " south korea";
+
+    public String type;
+
+    public CurrencyCommand(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public boolean execute(Wallet wallet) {
+        if (type != null) {
+            CurrencyThread currencyThread = new CurrencyThread(wallet, type);
+        } else {
+            System.out.println(MESSAGE_ADDING_CURRENCY);
+            System.out.println(MESSAGE_USAGE);
+        }
+        return false;
+    }
+}

--- a/src/main/java/wallet/logic/parser/CurrencyParser.java
+++ b/src/main/java/wallet/logic/parser/CurrencyParser.java
@@ -1,0 +1,16 @@
+//@@author matthewng1996
+
+package wallet.logic.parser;
+
+import wallet.logic.command.CurrencyCommand;
+
+public class CurrencyParser implements Parser<CurrencyCommand> {
+
+    @Override
+    public CurrencyCommand parse(String input) {
+        if (!"".equals(input)) {
+            return new CurrencyCommand(input.toLowerCase());
+        }
+        return null;
+    }
+}

--- a/src/main/java/wallet/logic/parser/CurrencyParser.java
+++ b/src/main/java/wallet/logic/parser/CurrencyParser.java
@@ -4,6 +4,8 @@ package wallet.logic.parser;
 
 import wallet.logic.command.CurrencyCommand;
 
+import java.text.ParseException;
+
 public class CurrencyParser implements Parser<CurrencyCommand> {
 
     @Override

--- a/src/main/java/wallet/logic/parser/ParserManager.java
+++ b/src/main/java/wallet/logic/parser/ParserManager.java
@@ -2,6 +2,7 @@ package wallet.logic.parser;
 
 import wallet.logic.command.AddCommand;
 import wallet.logic.command.Command;
+import wallet.logic.command.CurrencyCommand;
 import wallet.logic.command.DeleteCommand;
 import wallet.logic.command.DoneCommand;
 import wallet.logic.command.EditCommand;
@@ -78,6 +79,9 @@ public class ParserManager {
 
         case RedoCommand.COMMAND_WORD:
             return new RedoCommand();
+
+        case CurrencyCommand.COMMAND_WORD:
+            return new CurrencyParser().parse(arguments[1]);
 
         default:
             return null;

--- a/src/main/java/wallet/model/Wallet.java
+++ b/src/main/java/wallet/model/Wallet.java
@@ -1,7 +1,6 @@
 package wallet.model;
 
 import wallet.model.contact.ContactList;
-import wallet.model.currency.Currency;
 import wallet.model.currency.CurrencyList;
 import wallet.model.record.BudgetList;
 import wallet.model.record.ExpenseList;

--- a/src/main/java/wallet/model/Wallet.java
+++ b/src/main/java/wallet/model/Wallet.java
@@ -1,6 +1,8 @@
 package wallet.model;
 
 import wallet.model.contact.ContactList;
+import wallet.model.currency.Currency;
+import wallet.model.currency.CurrencyList;
 import wallet.model.record.BudgetList;
 import wallet.model.record.ExpenseList;
 import wallet.model.record.LoanList;
@@ -12,12 +14,14 @@ public class Wallet {
     private ExpenseList expenseList;
     private ContactList contactList;
     private LoanList loanList;
+    private CurrencyList currencyList;
 
     /**
      * Default constructor with no data.
      */
     public Wallet() {
         this.budgetList = new BudgetList();
+        this.currencyList = new CurrencyList();
         this.recordList = new RecordList();
         this.expenseList = new ExpenseList();
         this.contactList = new ContactList();
@@ -26,19 +30,25 @@ public class Wallet {
 
     /**
      * Constructs a Wallet object.
+     * @param currencyList The currencyList object.
      * @param budgetList The BudgetList object.
      * @param recordList The RecordList object.
      * @param expenseList The ExpenseList object.
      * @param contactList The ContactList object.
      * @param loanList The LoanList object.
      */
-    public Wallet(BudgetList budgetList, RecordList recordList, ExpenseList expenseList,
+    public Wallet(CurrencyList currencyList, BudgetList budgetList, RecordList recordList, ExpenseList expenseList,
                   ContactList contactList, LoanList loanList) {
+        this.currencyList = currencyList;
         this.budgetList = budgetList;
         this.recordList = recordList;
         this.expenseList = expenseList;
         this.contactList = contactList;
         this.loanList = loanList;
+    }
+
+    public CurrencyList getCurrencyList() {
+        return currencyList;
     }
 
     public BudgetList getBudgetList() {

--- a/src/main/java/wallet/model/currency/Currency.java
+++ b/src/main/java/wallet/model/currency/Currency.java
@@ -1,0 +1,79 @@
+//@@author matthewng1996
+
+package wallet.model.currency;
+
+public class Currency {
+    private String country;
+    private double value;
+    private boolean currentCurrency;
+
+    /**
+     * Constructs the Currency object.
+     * @param country which country the currency belongs to.
+     * @param value converted value from SGD.
+     */
+    public Currency(String country, double value, boolean currentCurrency) {
+        this.country = country;
+        this.value = value;
+        this.currentCurrency = currentCurrency;
+    }
+
+    /**
+     * Returns the country of the currency.
+     *
+     * @return The country of currency.
+     */
+    public String getCountry() {
+        return country;
+    }
+
+    /**
+     * Sets the country of currency.
+     *
+     * @param country The country the currency belongs to.
+     */
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    /**
+     * Returns the conversion value of the currency based on SGD.
+     *
+     * @return The conversion value of the currency
+     */
+    public double getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the value of the currency.
+     *
+     * @param value The value of the currency.
+     */
+    public void setValue(double value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets a boolean based on currenct currency.
+     *
+     * @return Whether currency is currently used.
+     */
+    public boolean isCurrentCurrency() {
+        return currentCurrency;
+    }
+
+    /**
+     * Sets a boolean based on currenct currency.
+     *
+     * @param currentCurrency The currently used currency.
+     */
+    public void setCurrentCurrency(boolean currentCurrency) {
+        this.currentCurrency = currentCurrency;
+    }
+
+
+    public String writeToFile() {
+        return country + ", " + value + ", " + currentCurrency;
+    }
+}

--- a/src/main/java/wallet/model/currency/CurrencyList.java
+++ b/src/main/java/wallet/model/currency/CurrencyList.java
@@ -1,0 +1,70 @@
+//@@author matthewng1996
+
+package wallet.model.currency;
+
+import java.util.ArrayList;
+
+public class CurrencyList {
+    private ArrayList<Currency> currencyList;
+    private Currency currentCurrency;
+    private boolean isModified = false;
+
+    public CurrencyList() {
+        this.currencyList = new ArrayList<>();
+    }
+
+    /**
+     * Constructs a new currencyList object.
+     *
+     * @param currencyArrayList The list of currencies to be added.
+     */
+    public CurrencyList(ArrayList<Currency> currencyArrayList) {
+        this.currencyList = currencyArrayList;
+        for (Currency c : currencyArrayList) {
+            if (c.isCurrentCurrency()) {
+                currentCurrency = c;
+            }
+        }
+    }
+
+    /**
+     * Returns the list of currencies in the currencyList.
+     *
+     * @return The list of currencies.
+     */
+    public ArrayList<Currency> getCurrencyList() {
+        return currencyList;
+    }
+
+    /**
+     * Returns a Currency object.
+     * @return current currency
+     */
+    public Currency getCurrentCurrency() {
+        return currentCurrency;
+    }
+
+    /**
+     * Returns a Currency object.
+     * @param currentCurrency The current currency
+     * @return current currency
+     */
+    public Currency setCurrentCurrency(Currency currentCurrency) {
+        return this.currentCurrency = currentCurrency;
+    }
+
+    /**
+     * Returns true if list is modified, else false.
+     */
+    public boolean getIsModified() {
+        return isModified;
+    }
+
+    /**
+     * Sets status of whether list is modified.
+     */
+    public void setModified(boolean modified) {
+        isModified = modified;
+    }
+
+}

--- a/src/main/java/wallet/model/record/Notes.java
+++ b/src/main/java/wallet/model/record/Notes.java
@@ -1,4 +1,0 @@
-package wallet.model.record;
-
-public class Notes {
-}

--- a/src/main/java/wallet/storage/CurrencyStorage.java
+++ b/src/main/java/wallet/storage/CurrencyStorage.java
@@ -1,0 +1,48 @@
+//@@author matthewng1996
+
+package wallet.storage;
+
+import wallet.model.currency.Currency;
+
+import java.io.*;
+import java.util.ArrayList;
+
+public class CurrencyStorage {
+
+    public static final String DEFAULT_STORAGE_FILEPATH_CURRENCY = "/currency.txt";
+
+    public ArrayList<Currency> loadFile() {
+        ArrayList<Currency> currencyList = new ArrayList<>();
+        try {
+            InputStream is = getClass().getResourceAsStream(DEFAULT_STORAGE_FILEPATH_CURRENCY);
+            InputStreamReader isr = new InputStreamReader(is);
+            BufferedReader br = new BufferedReader(isr);
+            String str;
+            while ((str = br.readLine()) != null) {
+                String[] data = str.split(",");
+                if (!data[0].isEmpty() && !data[1].isEmpty() && !data[2].isEmpty()) {
+                    if (data[2].trim().equals("false")) {
+                        Currency currency = new Currency(data[0].trim().toLowerCase(),
+                                Double.parseDouble(data[1]),
+                                false);
+                        currencyList.add(currency);
+                    } else {
+                        Currency currency = new Currency(data[0].trim().toLowerCase(),
+                                Double.parseDouble(data[1]),
+                                true);
+                        currencyList.add(currency);
+                    }
+                }
+            }
+            br.close();
+            isr.close();
+            is.close();
+        } catch (FileNotFoundException e) {
+            System.out.println("No saved currencies found.");
+        } catch (IOException e) {
+            System.out.println("End of file.");
+        }
+
+        return currencyList;
+    }
+}

--- a/src/main/java/wallet/storage/CurrencyStorage.java
+++ b/src/main/java/wallet/storage/CurrencyStorage.java
@@ -4,13 +4,24 @@ package wallet.storage;
 
 import wallet.model.currency.Currency;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 
+/**
+ * This class deals with loading of Currency from currency.txt
+ */
 public class CurrencyStorage {
 
     public static final String DEFAULT_STORAGE_FILEPATH_CURRENCY = "/currency.txt";
 
+    /**
+     * This method loads the currency.txt list into currentList for use in currency conversion.
+     * @return returns a list of currencies
+     */
     public ArrayList<Currency> loadFile() {
         ArrayList<Currency> currencyList = new ArrayList<>();
         try {

--- a/src/main/java/wallet/storage/StorageManager.java
+++ b/src/main/java/wallet/storage/StorageManager.java
@@ -2,7 +2,6 @@ package wallet.storage;
 
 import wallet.model.Wallet;
 import wallet.model.contact.Contact;
-import wallet.model.currency.Currency;
 import wallet.model.record.Budget;
 import wallet.model.record.Expense;
 import wallet.model.record.Loan;

--- a/src/main/java/wallet/storage/StorageManager.java
+++ b/src/main/java/wallet/storage/StorageManager.java
@@ -2,6 +2,7 @@ package wallet.storage;
 
 import wallet.model.Wallet;
 import wallet.model.contact.Contact;
+import wallet.model.currency.Currency;
 import wallet.model.record.Budget;
 import wallet.model.record.Expense;
 import wallet.model.record.Loan;

--- a/src/main/java/wallet/thread/CurrencyThread.java
+++ b/src/main/java/wallet/thread/CurrencyThread.java
@@ -5,12 +5,8 @@ package wallet.thread;
 import wallet.logic.command.CurrencyCommand;
 import wallet.model.Wallet;
 import wallet.model.currency.Currency;
-import wallet.model.currency.CurrencyList;
 import wallet.model.record.Expense;
 import wallet.model.record.Loan;
-import wallet.storage.CurrencyStorage;
-
-import java.util.ArrayList;
 
 public class CurrencyThread implements Runnable {
     private Wallet wallet;

--- a/src/main/java/wallet/thread/CurrencyThread.java
+++ b/src/main/java/wallet/thread/CurrencyThread.java
@@ -1,0 +1,80 @@
+//@@author matthewng1996
+
+package wallet.thread;
+
+import wallet.logic.command.CurrencyCommand;
+import wallet.model.Wallet;
+import wallet.model.currency.Currency;
+import wallet.model.currency.CurrencyList;
+import wallet.model.record.Expense;
+import wallet.model.record.Loan;
+import wallet.storage.CurrencyStorage;
+
+import java.util.ArrayList;
+
+public class CurrencyThread implements Runnable {
+    private Wallet wallet;
+    private Thread thread;
+    private String givenCountry;
+    private boolean isExit = false;
+
+    /**
+     * Custom thread.
+     */
+    public CurrencyThread(Wallet walletParam, String type) {
+        thread = new Thread(this);
+        thread.start();
+        wallet = walletParam;
+        givenCountry = type;
+    }
+
+    /**
+     * Runs the threat and stops when pie chart is completed.
+     */
+    @Override
+    public void run() {
+        for (Currency c : wallet.getCurrencyList().getCurrencyList()) {
+            if (c.getCountry().toLowerCase().equals(givenCountry)) {
+                updateExpenseAndLoans(wallet, c);
+                System.out.println(CurrencyCommand.MESSAGE_SUCCESSFUL_CONVERSION + givenCountry);
+                System.out.println(CurrencyCommand.MESSAGE_ADDING_CURRENCY);
+                isExit = true;
+            }
+        }
+        if (!isExit) {
+            System.out.println(CurrencyCommand.MESSAGE_NO_CURRENCY + givenCountry);
+        }
+        stop();
+    }
+
+    /**
+     * Stops the threat from running.
+     */
+    public void stop() {
+        thread.interrupt();
+    }
+
+    /**
+     * This method updates the amount in expenses and loans but does not save it.
+     * @param wallet Wallet object
+     * @param newCurrency newly chosen currency for conversion
+     */
+    public void updateExpenseAndLoans(Wallet wallet, Currency newCurrency) {
+        if (newCurrency != null) {
+            for (Expense e : wallet.getExpenseList().getExpenseList()) {
+                e.setAmount(e.getAmount()
+                        / wallet.getCurrencyList().getCurrentCurrency().getValue()
+                        * newCurrency.getValue());
+            }
+
+            for (Loan l : wallet.getLoanList().getLoanList()) {
+                l.setAmount(l.getAmount()
+                        / wallet.getCurrencyList().getCurrentCurrency().getValue()
+                        * newCurrency.getValue());
+            }
+            wallet.getCurrencyList().getCurrentCurrency().setCurrentCurrency(false);
+            newCurrency.setCurrentCurrency(true);
+            wallet.getCurrencyList().setCurrentCurrency(newCurrency);
+        }
+    }
+}

--- a/src/main/resources/currency.txt
+++ b/src/main/resources/currency.txt
@@ -1,0 +1,76 @@
+andorra, 0.66, false
+argentina, 43.95, false
+austria, 0.66, false
+australia, 1.08, false
+bahrain, 0.28, false
+belgium, 0.66, false
+botswana, 7.95, false
+brazil, 2.94, false
+brunei, 1.0, false
+bulgaria, 1.29, false
+canada, 0.96, false
+chile, 533.22, false
+china, 5.18, false
+colombia, 2490.3, false
+croatia, 4.93, false
+cyprus, 0.66, false
+czech republic, 16.91, false
+denmark, 4.94, false
+estonia, 0.66, false
+finland, 0.66, false
+france, 0.66, false
+germany, 0.66, false
+greece, 0.66, false
+hong kong, 5.75, false
+hungary, 217.68, false
+iceland, 91.55, false
+india, 51.97, false
+indonesia, 10294.18, false
+iran, 30825.44, false
+ireland, 0.66, false
+israel, 2.59, false
+italy, 0.66, false
+japan, 79.7, false
+kazakhstan, 285.65, false
+kuwait, 0.22, false
+libya, 1.03, false
+latvia, 0.66, false
+lithuania, 0.66, false
+luxembourg, 0.66, false
+malaysia, 3.07, false
+malta, 0.66, false
+mauritius, 26.64, false
+mexico, 13.98, false
+monaco, 0.66, false
+nepal, 83.53, false
+new zealand, 1.16, false
+norway, 6.75, false
+netherlands, 0.66, false
+oman, 0.28, false
+pakistan, 114.27, false
+philippines, 37.56, false
+poland, 2.83, false
+portugal, 0.66, false
+qatar, 2.67, false
+romania, 3.15, false
+russia, 46.86, false
+san marino, 0.66, false
+saudi arabia, 2.75, false
+singapore, 1.0, true
+slovakia, 0.66, false
+slovenia, 0.66, false
+spain, 0.66, false
+south africa, 10.73, false
+south korea, 859.5, false
+sri lanka, 133.13, false
+sweden, 7.1, false
+switzerland, 0.66, false
+taiwan, 22.42, false
+thailand, 22.12, false
+trinidad and tobago, 4.96, false
+turkey, 4.24, false
+united arab emirates, 2.69, false
+united kingdom, 0.57, false
+united states of america, 0.73, false
+vatican city, 0.66, false
+venezuela, 7.33, false

--- a/src/test/java/wallet/logic/command/CurrencyCommandTest.java
+++ b/src/test/java/wallet/logic/command/CurrencyCommandTest.java
@@ -1,0 +1,69 @@
+//@@author matthewng1996
+
+package wallet.logic.command;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import wallet.model.Wallet;
+import wallet.model.contact.ContactList;
+import wallet.model.currency.Currency;
+import wallet.model.currency.CurrencyList;
+import wallet.model.record.BudgetList;
+import wallet.model.record.Category;
+import wallet.model.record.Expense;
+import wallet.model.record.ExpenseList;
+import wallet.model.record.LoanList;
+import wallet.model.record.RecordList;
+import wallet.storage.CurrencyStorage;
+
+import java.text.DecimalFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CurrencyCommandTest {
+    private static CurrencyStorage currencyStorage = new CurrencyStorage();
+    private static Wallet testWallet = new Wallet(new CurrencyList(currencyStorage.loadFile()),
+            new BudgetList(),
+            new RecordList(),
+            new ExpenseList(),
+            new ContactList(),
+            new LoanList());
+    private static DecimalFormat df2 = new DecimalFormat("#.##");
+
+    /**
+     * Sets up the data by adding existing expenses.
+     */
+    @BeforeAll
+    public static void setUp() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        String date1 = "10/01/2019";
+        String date2 = "15/02/2019";
+        LocalDate localDate1 = LocalDate.parse(date1, formatter);
+        LocalDate localDate2 = LocalDate.parse(date2, formatter);
+
+        testWallet.getExpenseList().addExpense(new Expense("Lunch", localDate1, 1, Category.FOOD, false, null));
+        testWallet.getExpenseList().addExpense(new Expense("Dinner", localDate2, 5, Category.FOOD, false, null));
+    }
+
+    /**
+     * Test for currency conversion from Singapore Dollar to Italy Euros.
+     */
+    @Test
+    public void executeSingaporeDollarToItaly() {
+        Currency currency = new Currency("Italy", 0.66d, false);
+        CurrencyCommand currencyCommand = new CurrencyCommand(currency.getCountry().toLowerCase());
+        currencyCommand.execute(testWallet);
+
+        for (int i = 0; i < 100000; i++) {
+            //Do a slight delay for all expenses to update first...
+        }
+
+        assertEquals(String.format("%.2f", 0.66), String.format("%.2f",
+                testWallet.getExpenseList().getExpense(0).getAmount()));
+        assertEquals(String.format("%.2f", 3.30), String.format("%.2f",
+                testWallet.getExpenseList().getExpense(1).getAmount()));
+        assertEquals("italy", testWallet.getCurrencyList().getCurrentCurrency().getCountry());
+    }
+}

--- a/src/test/java/wallet/logic/command/CurrencyCommandTest.java
+++ b/src/test/java/wallet/logic/command/CurrencyCommandTest.java
@@ -30,7 +30,6 @@ public class CurrencyCommandTest {
             new ExpenseList(),
             new ContactList(),
             new LoanList());
-    private static DecimalFormat df2 = new DecimalFormat("#.##");
 
     /**
      * Sets up the data by adding existing expenses.
@@ -56,7 +55,7 @@ public class CurrencyCommandTest {
         CurrencyCommand currencyCommand = new CurrencyCommand(currency.getCountry().toLowerCase());
         currencyCommand.execute(testWallet);
 
-        for (int i = 0; i < 100000; i++) {
+        for (int i = 0; i < 1000000; i++) {
             //Do a slight delay for all expenses to update first...
         }
 

--- a/src/test/java/wallet/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/wallet/logic/parser/AddCommandParserTest.java
@@ -11,6 +11,7 @@ import wallet.model.Wallet;
 import wallet.model.WalletList;
 import wallet.model.contact.Contact;
 import wallet.model.contact.ContactList;
+import wallet.model.currency.CurrencyList;
 import wallet.model.record.BudgetList;
 import wallet.model.record.Category;
 import wallet.model.record.Expense;
@@ -59,7 +60,8 @@ public class AddCommandParserTest {
     public void parseLoan_validInput_success() throws ParseException {
         AddCommandParser parser = new AddCommandParser();
         WalletList dummyWalletList = new WalletList();
-        Wallet dummyWallet = new Wallet(new BudgetList(),
+        Wallet dummyWallet = new Wallet(new CurrencyList(),
+                new BudgetList(),
                 new RecordList(),
                 new ExpenseList(),
                 new ContactList(),

--- a/src/test/java/wallet/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/wallet/logic/parser/EditCommandParserTest.java
@@ -8,6 +8,7 @@ import wallet.model.Wallet;
 import wallet.model.WalletList;
 import wallet.model.contact.Contact;
 import wallet.model.contact.ContactList;
+import wallet.model.currency.CurrencyList;
 import wallet.model.record.BudgetList;
 import wallet.model.record.Category;
 import wallet.model.record.Expense;
@@ -106,7 +107,8 @@ public class EditCommandParserTest {
     public void parseLoan_validInput_success_case_description() {
         EditCommandParser parser = new EditCommandParser();
         WalletList dummyWalletList = new WalletList();
-        Wallet dummyWallet = new Wallet(new BudgetList(),
+        Wallet dummyWallet = new Wallet(new CurrencyList(),
+                new BudgetList(),
                 new RecordList(),
                 new ExpenseList(),
                 new ContactList(),
@@ -147,7 +149,8 @@ public class EditCommandParserTest {
     public void parseLoan_validInput_success_case_date() {
         EditCommandParser parser = new EditCommandParser();
         WalletList dummyWalletList = new WalletList();
-        Wallet dummyWallet = new Wallet(new BudgetList(),
+        Wallet dummyWallet = new Wallet(new CurrencyList(),
+                new BudgetList(),
                 new RecordList(),
                 new ExpenseList(),
                 new ContactList(),
@@ -188,7 +191,8 @@ public class EditCommandParserTest {
     public void parseLoan_validInput_success_case_amount() {
         EditCommandParser parser = new EditCommandParser();
         WalletList dummyWalletList = new WalletList();
-        Wallet dummyWallet = new Wallet(new BudgetList(),
+        Wallet dummyWallet = new Wallet(new CurrencyList(),
+                new BudgetList(),
                 new RecordList(),
                 new ExpenseList(),
                 new ContactList(),
@@ -229,7 +233,8 @@ public class EditCommandParserTest {
     public void parseLoan_validInput_success_case_isLend() {
         EditCommandParser parser = new EditCommandParser();
         WalletList dummyWalletList = new WalletList();
-        Wallet dummyWallet = new Wallet(new BudgetList(),
+        Wallet dummyWallet = new Wallet(new CurrencyList(),
+                new BudgetList(),
                 new RecordList(),
                 new ExpenseList(),
                 new ContactList(),
@@ -270,7 +275,8 @@ public class EditCommandParserTest {
     public void parseLoan_validInput_success_case_contact() {
         EditCommandParser parser = new EditCommandParser();
         WalletList dummyWalletList = new WalletList();
-        Wallet dummyWallet = new Wallet(new BudgetList(),
+        Wallet dummyWallet = new Wallet(new CurrencyList(),
+                new BudgetList(),
                 new RecordList(),
                 new ExpenseList(),
                 new ContactList(),


### PR DESCRIPTION
New command added `currency <country>`
Users can now convert currency across Expenses and Loans by specifying country
- Both Expense and Loans data, however **WILL NOT BE SAVED**. It's not a bug, the conversion only happens for that session of WalletCLi. Once u exit, the currency will revert back to normal (SGD).
- Users can modify the conversion list to add new countries or modify the exchange rates accordingly.

****Don't merge the PR yet, cos i havent do Junit Test for this... And i have a few other changes that i will do later.**