### PR TITLE
Standardize Exception and other matters

### DIFF
--- a/src/main/java/wallet/logic/LogicManager.java
+++ b/src/main/java/wallet/logic/LogicManager.java
@@ -116,7 +116,7 @@ public class LogicManager {
                     commandHistory.add(fullCommand);
                 }
             } else {
-                System.out.println(MESSAGE_ERROR_COMMAND);
+                Ui.printError(MESSAGE_ERROR_COMMAND);
             }
         } catch (WrongDateTimeFormat | WrongParameterFormat | InsufficientParameters | ParseException err) {
             Ui.printError(err.toString());

--- a/src/main/java/wallet/logic/command/CurrencyCommand.java
+++ b/src/main/java/wallet/logic/command/CurrencyCommand.java
@@ -4,14 +4,13 @@ package wallet.logic.command;
 
 import wallet.model.Wallet;
 import wallet.thread.CurrencyThread;
+import wallet.ui.Ui;
 
 public class CurrencyCommand extends Command {
     public static final String COMMAND_WORD = "currency";
 
     public static final String MESSAGE_NO_CURRENCY = "There is no such currency found for the conversion to ";
     public static final String MESSAGE_SUCCESSFUL_CONVERSION = "Your currency is converted to the country of ";
-    public static final String MESSAGE_ADDING_CURRENCY =
-            "You can add or modify your own currency conversion in /currency.txt";
     public static final String MESSAGE_USAGE = "Error in format for command."
             + "\nExample: " + COMMAND_WORD + " singapore"
             + "\nExample: " + COMMAND_WORD + " south korea";
@@ -27,8 +26,7 @@ public class CurrencyCommand extends Command {
         if (type != null) {
             CurrencyThread currencyThread = new CurrencyThread(wallet, type);
         } else {
-            System.out.println(MESSAGE_ADDING_CURRENCY);
-            System.out.println(MESSAGE_USAGE);
+            Ui.printError(MESSAGE_USAGE);
         }
         return false;
     }

--- a/src/main/java/wallet/logic/command/DeleteCommand.java
+++ b/src/main/java/wallet/logic/command/DeleteCommand.java
@@ -16,10 +16,10 @@ public class DeleteCommand extends Command {
             + "\ndelete expense <id>"
             + "\nExample: " + COMMAND_WORD + " expense 2";
     public static final String MESSAGE_SUCCESS_DELETE_EXPENSE = "Noted. I've removed this expense:";
-    public static final String MESSAGE_ERROR_DELETE_EXPENSE = "An error occurred when trying to delete expense.";
     public static final String MESSAGE_SUCCESS_DELETE_LOAN = "Noted. I've removed this loan:";
-    public static final String MESSAGE_ERROR_DELETE_LOAN = "An error occurred when trying to delete loan.";
     public static final String MESSAGE_SUCCESS_DELETE_CONTACT = "Noted. I've removed this contact:";
+    public static final String MESSAGE_ERROR_DELETE_EXPENSE = "An error occurred when trying to delete expense.";
+    public static final String MESSAGE_ERROR_DELETE_LOAN = "An error occurred when trying to delete loan.";
     public static final String MESSAGE_ERROR_DELETE_CONTACT = "An error occurred when trying to delete contact.";
     public static final String MESSAGE_ERROR_LOAN_USAGE = "There are loans using this contact. Unable to delete!";
     private String object;
@@ -54,7 +54,7 @@ public class DeleteCommand extends Command {
                 System.out.println(MESSAGE_SUCCESS_DELETE_EXPENSE);
                 Ui.printExpense(expense);
             } else {
-                System.out.println(MESSAGE_ERROR_DELETE_EXPENSE);
+                Ui.printError(MESSAGE_ERROR_DELETE_EXPENSE);
             }
             break;
         //@@author
@@ -73,7 +73,7 @@ public class DeleteCommand extends Command {
                     System.out.println("Turning off auto reminders because all loans have been settled!");
                 }
             } else {
-                System.out.println(MESSAGE_ERROR_DELETE_LOAN);
+                Ui.printError(MESSAGE_ERROR_DELETE_LOAN);
             }
             break;
         //@@author
@@ -82,7 +82,7 @@ public class DeleteCommand extends Command {
             //@@author Xdecosee
             for (Loan l : wallet.getLoanList().getLoanList()) {
                 if (l.getPerson().getId() == id) {
-                    System.out.println(MESSAGE_ERROR_LOAN_USAGE);
+                    Ui.printError(MESSAGE_ERROR_LOAN_USAGE);
                     return false;
                 }
             }
@@ -93,7 +93,7 @@ public class DeleteCommand extends Command {
                 System.out.println(MESSAGE_SUCCESS_DELETE_CONTACT);
                 Ui.printContact(contact);
             } else {
-                System.out.println(MESSAGE_ERROR_DELETE_CONTACT);
+                Ui.printError(MESSAGE_ERROR_DELETE_CONTACT);
             }
             break;
             //@@author

--- a/src/main/java/wallet/logic/command/DoneCommand.java
+++ b/src/main/java/wallet/logic/command/DoneCommand.java
@@ -42,12 +42,12 @@ public class DoneCommand extends Command {
             Loan loan = wallet.getLoanList().findLoanWithId(id);
             if (loan != null) {
                 if (loan.getIsSettled()) {
-                    System.out.println(MESSAGE_FAILURE_ALREADY_DONE);
+                    Ui.printError(MESSAGE_FAILURE_ALREADY_DONE);
                     return false;
                 }
                 loan.setIsSettled(true);
             } else {
-                System.out.println(MESSAGE_FAILURE_NO_SUCH_ID);
+                Ui.printError(MESSAGE_FAILURE_NO_SUCH_ID);
                 return false;
             }
             wallet.getLoanList().setModified(true);
@@ -61,7 +61,7 @@ public class DoneCommand extends Command {
                 System.out.println("Great! All loans have been settled!");
             }
         } catch (Exception e) {
-            System.out.println(MESSAGE_FAILURE_DONE);
+            Ui.printError(MESSAGE_FAILURE_DONE);
         }
         return false;
     }

--- a/src/main/java/wallet/logic/command/EditCommand.java
+++ b/src/main/java/wallet/logic/command/EditCommand.java
@@ -23,7 +23,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_SUCCESS_EDIT_CONTACT = "Successfully edited this contact:";
     public static final String MESSAGE_SUCCESS_EDIT_LOAN = "Successfully edited this loan:";
     public static final String MESSAGE_ERROR_FORMAT = "Your format for edit command is wrong.";
-    public static final String MESSAGE_ERROR_COMMAND = "An error encountered while executing command.";
+    public static final String MESSAGE_ERROR_COMMAND = "An error encountered while executing edit command.";
     public static final String MESSAGE_ERROR_ID_DOES_NOT_EXIST = "The ID given does not exist.";
 
 
@@ -67,7 +67,7 @@ public class EditCommand extends Command {
             try {
                 currentExpense = wallet.getExpenseList().getExpense(index);
             } catch (IndexOutOfBoundsException ex) {
-                System.out.println(MESSAGE_ERROR_ID_DOES_NOT_EXIST);
+                Ui.printError(MESSAGE_ERROR_ID_DOES_NOT_EXIST);
                 return false;
             }
             if (expense.getRecFrequency() != null) {
@@ -128,7 +128,7 @@ public class EditCommand extends Command {
                 System.out.println(MESSAGE_SUCCESS_EDIT_CONTACT);
                 Ui.printContact(currentContact);
             } else {
-                System.out.println(MESSAGE_ERROR_COMMAND);
+                Ui.printError(MESSAGE_ERROR_COMMAND);
             }
             //@@author
         } else if (loan != null) {
@@ -152,7 +152,7 @@ public class EditCommand extends Command {
                 Ui.printLoanRow(updatedLoan);
                 Ui.printLoanTableClose();
             } else {
-                System.out.println(MESSAGE_ERROR_COMMAND);
+                Ui.printError(MESSAGE_ERROR_COMMAND);
             }
         }
         //@@author

--- a/src/main/java/wallet/logic/command/ExportCommand.java
+++ b/src/main/java/wallet/logic/command/ExportCommand.java
@@ -4,6 +4,7 @@ package wallet.logic.command;
 
 import com.opencsv.CSVWriter;
 import wallet.model.Wallet;
+import wallet.ui.Ui;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -16,7 +17,7 @@ import java.util.List;
 public class ExportCommand extends Command {
 
     public static final String COMMAND_WORD = "export";
-    private static final String MESSAGE_ERROR_WRITING_CSV = "Error in writing to csv!";
+    private static final String MESSAGE_ERROR_WRITING_CSV = "Error in exporting data to csv!";
     private static final String MESSAGE_SUCCESS_WRITING_CSV = "Export success! File saved to -> ";
     private List<String[]> data;
     private String type;
@@ -64,11 +65,11 @@ public class ExportCommand extends Command {
                 output.close();
                 System.out.println(MESSAGE_SUCCESS_WRITING_CSV + csv);
             } else {
-                System.out.println(MESSAGE_ERROR_WRITING_CSV);
+                Ui.printError(MESSAGE_ERROR_WRITING_CSV);
             }
 
         } catch (URISyntaxException | IOException e) {
-            System.out.println(MESSAGE_ERROR_WRITING_CSV);
+            Ui.printError(MESSAGE_ERROR_WRITING_CSV);
         }
 
 

--- a/src/main/java/wallet/logic/command/HelpCommand.java
+++ b/src/main/java/wallet/logic/command/HelpCommand.java
@@ -1,6 +1,7 @@
 package wallet.logic.command;
 
 import wallet.model.Wallet;
+import wallet.ui.Ui;
 
 import java.util.ArrayList;
 
@@ -30,7 +31,7 @@ public class HelpCommand extends Command {
         try {
             chosenIndex = Integer.parseInt(input);
             if (chosenIndex <= 0 || chosenIndex > wallet.getHelpList().size()) {
-                System.out.println(MESSAGE_ERROR_INDEX);
+                Ui.printError(MESSAGE_ERROR_INDEX);
                 return false;
             }
             ArrayList<String> sectionData = wallet.getHelpList().get(chosenIndex - 1).getSectionData();
@@ -38,7 +39,7 @@ public class HelpCommand extends Command {
                 System.out.println(s);
             }
         } catch (NumberFormatException e) {
-            System.out.println(MESSAGE_ERROR_INDEX);
+            Ui.printError(MESSAGE_ERROR_INDEX);
         }
         return false;
         //@@author

--- a/src/main/java/wallet/logic/command/HistoryCommand.java
+++ b/src/main/java/wallet/logic/command/HistoryCommand.java
@@ -11,7 +11,7 @@ public class HistoryCommand extends Command {
 
     public static final String COMMAND_WORD = "history";
     public static final String MESSAGE_LIST_HISTORY = "Command History from earliest to latest:";
-    public static final String MESSAGE_USAGE = "Error in format for command.";
+    public static final String MESSAGE_USAGE = "Error in syntax for history command.";
 
     private ArrayList<String> commandHistory;
 

--- a/src/main/java/wallet/logic/command/ImportCommand.java
+++ b/src/main/java/wallet/logic/command/ImportCommand.java
@@ -7,9 +7,7 @@ import wallet.model.record.ExpenseList;
 import wallet.model.record.LoanList;
 import wallet.model.record.Expense;
 import wallet.model.record.Loan;
-import wallet.model.record.Budget;
 
-import java.text.DateFormatSymbols;
 import java.time.LocalDate;
 import java.util.ArrayList;
 
@@ -19,9 +17,8 @@ public class ImportCommand extends Command {
     private static final String MESSAGE_SUCCESS_ADD_CONTACT = "Got it. I've added this contact:";
     private static final String MESSAGE_SUCCESS_ADD_EXPENSE = "Got it. I've added this expense:";
     private static final String MESSAGE_SUCCESS_ADD_LOAN = "Got it. I've added this loan:";
-    private static final String MESSAGE_NEW_BUDGET = " is your new budget for ";
-    private static final String MESSAGE_EXCEED_BUDGET = "Your budget has exceeded!!";
-    private static final String MESSAGE_REACH_BUDGET = "You have reached your budget!!";
+    private static final String MESSAGE_IMPORT_PROGRESS = "Importing records...";
+    private static final String MESSAGE_IMPORT_FINISH = "Finish Import!";
     private LoanList loanList = null;
     private ExpenseList expenseList = null;
 
@@ -52,7 +49,7 @@ public class ImportCommand extends Command {
     @Override
     public boolean execute(Wallet wallet) {
 
-        System.out.println("Importing records... \n");
+        System.out.println(MESSAGE_IMPORT_PROGRESS + "\n");
 
         if (loanList != null) {
 
@@ -85,19 +82,6 @@ public class ImportCommand extends Command {
             for (Expense expense : expenseData) {
                 wallet.getExpenseList().addExpense(expense);
                 LocalDate date = expense.getDate();
-                for (Budget b : wallet.getBudgetList().getBudgetList()) {
-                    if (b.getMonth() == date.getMonthValue() && b.getYear() == date.getYear()) {
-                        b.setAmount(b.getAmount() - expense.getAmount());
-                        wallet.getBudgetList().setModified(true);
-                        if (b.getAmount() < 0) {
-                            System.out.println(MESSAGE_EXCEED_BUDGET);
-                        } else if (b.getAmount() == 0) {
-                            System.out.println(MESSAGE_REACH_BUDGET);
-                        }
-                        System.out.println("$" + b.getAmount() + MESSAGE_NEW_BUDGET
-                                + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
-                    }
-                }
                 wallet.getRecordList().addRecord(expense);
                 wallet.getExpenseList().setModified(true);
                 System.out.println(MESSAGE_SUCCESS_ADD_EXPENSE);
@@ -106,7 +90,7 @@ public class ImportCommand extends Command {
             }
         }
 
-        System.out.println("Finish Import!");
+        System.out.println(MESSAGE_IMPORT_FINISH);
         return false;
     }
 }

--- a/src/main/java/wallet/logic/command/ListCommand.java
+++ b/src/main/java/wallet/logic/command/ListCommand.java
@@ -73,10 +73,10 @@ public class ListCommand extends Command {
                         System.out.println(MESSAGE_LIST_EXPENSES);
                         Ui.printExpenseTable(expenseList);
                     } else {
-                        System.out.println(MESSAGE_RECURRING_SORT);
+                        Ui.printError(MESSAGE_RECURRING_SORT);
                     }
                 } else {
-                    System.out.println(MESSAGE_USAGE);
+                    Ui.printError(MESSAGE_USAGE);
                 }
             }
         } else if (record.contains("all")) {
@@ -109,7 +109,7 @@ public class ListCommand extends Command {
                         System.out.println(MESSAGE_LIST_ALL_SORT);
                     }
                 } else {
-                    System.out.println(MESSAGE_USAGE);
+                    Ui.printError(MESSAGE_USAGE);
                 }
             }
         } else if (record.contains("contact")) {
@@ -121,7 +121,7 @@ public class ListCommand extends Command {
             } else {
                 String[] arguments = record.split(" ", 3);
                 if (arguments.length < 3) {
-                    System.out.println(MESSAGE_CONTACT_SORT);
+                    Ui.printError(MESSAGE_CONTACT_SORT);
                     return false;
                 }
                 if (arguments[1].equals("/sortby")) {
@@ -130,10 +130,10 @@ public class ListCommand extends Command {
                         System.out.println(MESSAGE_LIST_CONTACTS);
                         Ui.printContactTable(sortedContacts);
                     } else {
-                        System.out.println(MESSAGE_CONTACT_SORT);
+                        Ui.printError(MESSAGE_CONTACT_SORT);
                     }
                 } else {
-                    System.out.println(MESSAGE_USAGE);
+                    Ui.printError(MESSAGE_USAGE);
                 }
             }
 
@@ -157,10 +157,10 @@ public class ListCommand extends Command {
                         ArrayList<Loan> loanList = wallet.getLoanList().sortByBorrow();
                         Ui.printLoanTable(loanList);
                     } else {
-                        System.out.println(MESSAGE_LOANS_SORT);
+                        Ui.printError(MESSAGE_LOANS_SORT);
                     }
                 } else {
-                    System.out.println(MESSAGE_USAGE);
+                    Ui.printError(MESSAGE_USAGE);
                 }
             }
         } else if (record.contains("expense")) {
@@ -180,10 +180,10 @@ public class ListCommand extends Command {
                         System.out.println(MESSAGE_LIST_EXPENSES);
                         Ui.printExpenseTable(expenseList);
                     } else {
-                        System.out.println(MESSAGE_EXPENSE_SORT);
+                        Ui.printError(MESSAGE_EXPENSE_SORT);
                     }
                 } else {
-                    System.out.println(MESSAGE_USAGE);
+                    Ui.printError(MESSAGE_USAGE);
                 }
             }
         } else {
@@ -231,7 +231,7 @@ public class ListCommand extends Command {
                     }
                 }
             } else {
-                System.out.println(MESSAGE_USAGE);
+                Ui.printError(MESSAGE_USAGE);
             }
             //@@author
         }

--- a/src/main/java/wallet/logic/command/ReminderCommand.java
+++ b/src/main/java/wallet/logic/command/ReminderCommand.java
@@ -36,7 +36,7 @@ public class ReminderCommand extends Command {
         if (info.length == 1) {
             if (info[0].equals("on")) {
                 if (LogicManager.getReminder().getAutoRemind()) {
-                    System.out.println(MESSAGE_FAILURE_REMINDER_ON);
+                    Ui.printError(MESSAGE_FAILURE_REMINDER_ON);
                 } else {
                     LogicManager.getReminder().setAutoRemind(true);
                     LogicManager.getReminder().autoRemindStart();
@@ -44,7 +44,7 @@ public class ReminderCommand extends Command {
                 }
             } else if (info[0].equals("off")) {
                 if (!LogicManager.getReminder().getAutoRemind()) {
-                    System.out.println(MESSAGE_FAILURE_REMINDER_OFF);
+                    Ui.printError(MESSAGE_FAILURE_REMINDER_OFF);
                 } else {
                     LogicManager.getReminder().autoRemindStop();
                     System.out.println(ReminderCommand.MESSAGE_SUCCESS_REMINDER_OFF);
@@ -70,7 +70,7 @@ public class ReminderCommand extends Command {
                 }
             }
         } else {
-            System.out.println(MESSAGE_USAGE);
+            Ui.printError(MESSAGE_USAGE);
         }
         return false;
     }

--- a/src/main/java/wallet/logic/command/SetBudgetCommand.java
+++ b/src/main/java/wallet/logic/command/SetBudgetCommand.java
@@ -6,6 +6,7 @@ import wallet.model.Wallet;
 import wallet.model.record.Budget;
 import wallet.model.record.BudgetList;
 import wallet.model.record.Expense;
+import wallet.ui.Ui;
 
 import java.text.DateFormatSymbols;
 import java.time.LocalDate;
@@ -44,7 +45,7 @@ public class SetBudgetCommand extends Command {
             if (budget != null) {
                 BudgetList budgetList = wallet.getBudgetList();
                 if (budget.getAmount() < 0) {
-                    System.out.println(MESSAGE_NO_NEGATIVE_BUDGET);
+                    Ui.printError(MESSAGE_NO_NEGATIVE_BUDGET);
                     System.out.println(MESSAGE_USAGE);
                     return false;
                 } else if (budget.getAmount() > 0) {
@@ -88,7 +89,7 @@ public class SetBudgetCommand extends Command {
                     return false;
                 } else if (budget.getAmount() == 0) {
                     if (budgetList.getBudgetList().size() == 0) {
-                        System.out.println(MESSAGE_NO_BUDGET_TO_REMOVE);
+                        Ui.printError(MESSAGE_NO_BUDGET_TO_REMOVE);
                         return false;
                     } else {
                         int index = checkDuplicates(budgetList);
@@ -99,7 +100,7 @@ public class SetBudgetCommand extends Command {
                                     + new DateFormatSymbols().getMonths()[budget.getMonth() - 1]
                                     + " " + budget.getYear());
                         } else {
-                            System.out.println(MESSAGE_NO_BUDGET_TO_REMOVE);
+                            Ui.printError(MESSAGE_NO_BUDGET_TO_REMOVE);
                         }
                         return false;
                     }

--- a/src/main/java/wallet/logic/command/UndoCommand.java
+++ b/src/main/java/wallet/logic/command/UndoCommand.java
@@ -5,6 +5,7 @@ package wallet.logic.command;
 import wallet.logic.LogicManager;
 import wallet.model.Wallet;
 import wallet.model.WalletList;
+import wallet.ui.Ui;
 
 public class UndoCommand extends Command {
 
@@ -23,7 +24,7 @@ public class UndoCommand extends Command {
     public boolean execute(Wallet wallet) {
 
         if (walletList.getState() == 0) {
-            System.out.println(MESSAGE_ALREADY_INITIAL_STATE);
+            Ui.printError(MESSAGE_ALREADY_INITIAL_STATE);
             return false;
         }
 

--- a/src/main/java/wallet/logic/command/ViewCommand.java
+++ b/src/main/java/wallet/logic/command/ViewCommand.java
@@ -133,37 +133,37 @@ public class ViewCommand extends Command {
         for (Expense expense : expenseList) {
             if (expense.getDate().getMonthValue() == month && expense.getDate().getYear() == year) {
                 switch (expense.getCategory()) {
-                    case FOOD:
-                        if (categoryMap.get(Category.FOOD) == null) {
-                            categoryMap.put(Category.FOOD, new ArrayList<Expense>());
-                        }
-                        categoryMap.get(Category.FOOD).add(expense);
-                        break;
-                    case BILLS:
-                        if (categoryMap.get(Category.BILLS) == null) {
-                            categoryMap.put(Category.BILLS, new ArrayList<Expense>());
-                        }
-                        categoryMap.get(Category.BILLS).add(expense);
-                        break;
-                    case TRANSPORT:
-                        if (categoryMap.get(Category.TRANSPORT) == null) {
-                            categoryMap.put(Category.TRANSPORT, new ArrayList<Expense>());
-                        }
-                        categoryMap.get(Category.TRANSPORT).add(expense);
-                        break;
-                    case SHOPPING:
-                        if (categoryMap.get(Category.SHOPPING) == null) {
-                            categoryMap.put(Category.SHOPPING, new ArrayList<Expense>());
-                        }
-                        categoryMap.get(Category.SHOPPING).add(expense);
-                        break;
-                    case OTHERS:
-                        if (categoryMap.get(Category.OTHERS) == null) {
-                            categoryMap.put(Category.OTHERS, new ArrayList<Expense>());
-                        }
-                        categoryMap.get(Category.OTHERS).add(expense);
-                        break;
-                    default:
+                case FOOD:
+                    if (categoryMap.get(Category.FOOD) == null) {
+                        categoryMap.put(Category.FOOD, new ArrayList<Expense>());
+                    }
+                    categoryMap.get(Category.FOOD).add(expense);
+                    break;
+                case BILLS:
+                    if (categoryMap.get(Category.BILLS) == null) {
+                        categoryMap.put(Category.BILLS, new ArrayList<Expense>());
+                    }
+                    categoryMap.get(Category.BILLS).add(expense);
+                    break;
+                case TRANSPORT:
+                    if (categoryMap.get(Category.TRANSPORT) == null) {
+                        categoryMap.put(Category.TRANSPORT, new ArrayList<Expense>());
+                    }
+                    categoryMap.get(Category.TRANSPORT).add(expense);
+                    break;
+                case SHOPPING:
+                    if (categoryMap.get(Category.SHOPPING) == null) {
+                        categoryMap.put(Category.SHOPPING, new ArrayList<Expense>());
+                    }
+                    categoryMap.get(Category.SHOPPING).add(expense);
+                    break;
+                case OTHERS:
+                    if (categoryMap.get(Category.OTHERS) == null) {
+                        categoryMap.put(Category.OTHERS, new ArrayList<Expense>());
+                    }
+                    categoryMap.get(Category.OTHERS).add(expense);
+                    break;
+                default:
                 }
             }
         }

--- a/src/main/java/wallet/logic/command/ViewCommand.java
+++ b/src/main/java/wallet/logic/command/ViewCommand.java
@@ -3,7 +3,6 @@
 package wallet.logic.command;
 
 import wallet.exception.WrongParameterFormat;
-import wallet.logic.LogicManager;
 import wallet.model.Wallet;
 import wallet.model.record.Budget;
 import wallet.model.record.Category;
@@ -59,22 +58,22 @@ public class ViewCommand extends Command {
                                     + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
                             System.out.println("$" + b.getAmount());
 
-                           // double remainingBudget = b.getAmount()
-                                   // - wallet.getExpenseList().getMonthExpenses(b.getMonth(), b.getYear());
+                            // double remainingBudget = b.getAmount()
+                            // - wallet.getExpenseList().getMonthExpenses(b.getMonth(), b.getYear());
 
                             BigDecimal monthBudget = BigDecimal.valueOf(b.getAmount());
-                            BigDecimal expenseSum = BigDecimal.valueOf( wallet.getExpenseList()
+                            BigDecimal expenseSum = BigDecimal.valueOf(wallet.getExpenseList()
                                 .getMonthExpenses(b.getMonth(), b.getYear()));
                             double remainingBudget = monthBudget.subtract(expenseSum).doubleValue();
 
                             System.out.println(MESSAGE_REMAINING_BUDGET
-                                    + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
+                                + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
                             System.out.println("$" + remainingBudget);
                             return false;
                         }
                     }
                     System.out.println(MESSAGE_EMPTY_BUDGET
-                            +  new DateFormatSymbols().getMonths()[month - 1] + " " + year);
+                            + new DateFormatSymbols().getMonths()[month - 1] + " " + year);
                 } else if (type[0].equals("stats")) {
                     //@@author kyang96
                     HashMap<Category, ArrayList<Expense>> categoryMap
@@ -121,48 +120,50 @@ public class ViewCommand extends Command {
     }
 
     //@@author kyang96
+
     /**
      * Generate a HashMap containing all expenses of a certain month in each category.
+     *
      * @param expenseList The entire list of expenses.
-     * @param month The month to filter.
-     * @param year The year to filter.
+     * @param month       The month to filter.
+     * @param year        The year to filter.
      */
     public HashMap<Category, ArrayList<Expense>> getCategoryMap(ArrayList<Expense> expenseList, int month, int year) {
         HashMap<Category, ArrayList<Expense>> categoryMap = new HashMap<>();
         for (Expense expense : expenseList) {
             if (expense.getDate().getMonthValue() == month && expense.getDate().getYear() == year) {
                 switch (expense.getCategory()) {
-                case FOOD:
-                    if (categoryMap.get(Category.FOOD) == null) {
-                        categoryMap.put(Category.FOOD, new ArrayList<Expense>());
-                    }
-                    categoryMap.get(Category.FOOD).add(expense);
-                    break;
-                case BILLS:
-                    if (categoryMap.get(Category.BILLS) == null) {
-                        categoryMap.put(Category.BILLS, new ArrayList<Expense>());
-                    }
-                    categoryMap.get(Category.BILLS).add(expense);
-                    break;
-                case TRANSPORT:
-                    if (categoryMap.get(Category.TRANSPORT) == null) {
-                        categoryMap.put(Category.TRANSPORT, new ArrayList<Expense>());
-                    }
-                    categoryMap.get(Category.TRANSPORT).add(expense);
-                    break;
-                case SHOPPING:
-                    if (categoryMap.get(Category.SHOPPING) == null) {
-                        categoryMap.put(Category.SHOPPING, new ArrayList<Expense>());
-                    }
-                    categoryMap.get(Category.SHOPPING).add(expense);
-                    break;
-                case OTHERS:
-                    if (categoryMap.get(Category.OTHERS) == null) {
-                        categoryMap.put(Category.OTHERS, new ArrayList<Expense>());
-                    }
-                    categoryMap.get(Category.OTHERS).add(expense);
-                    break;
-                default:
+                    case FOOD:
+                        if (categoryMap.get(Category.FOOD) == null) {
+                            categoryMap.put(Category.FOOD, new ArrayList<Expense>());
+                        }
+                        categoryMap.get(Category.FOOD).add(expense);
+                        break;
+                    case BILLS:
+                        if (categoryMap.get(Category.BILLS) == null) {
+                            categoryMap.put(Category.BILLS, new ArrayList<Expense>());
+                        }
+                        categoryMap.get(Category.BILLS).add(expense);
+                        break;
+                    case TRANSPORT:
+                        if (categoryMap.get(Category.TRANSPORT) == null) {
+                            categoryMap.put(Category.TRANSPORT, new ArrayList<Expense>());
+                        }
+                        categoryMap.get(Category.TRANSPORT).add(expense);
+                        break;
+                    case SHOPPING:
+                        if (categoryMap.get(Category.SHOPPING) == null) {
+                            categoryMap.put(Category.SHOPPING, new ArrayList<Expense>());
+                        }
+                        categoryMap.get(Category.SHOPPING).add(expense);
+                        break;
+                    case OTHERS:
+                        if (categoryMap.get(Category.OTHERS) == null) {
+                            categoryMap.put(Category.OTHERS, new ArrayList<Expense>());
+                        }
+                        categoryMap.get(Category.OTHERS).add(expense);
+                        break;
+                    default:
                 }
             }
         }

--- a/src/main/java/wallet/logic/command/ViewCommand.java
+++ b/src/main/java/wallet/logic/command/ViewCommand.java
@@ -58,9 +58,6 @@ public class ViewCommand extends Command {
                                     + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
                             System.out.println("$" + b.getAmount());
 
-                            // double remainingBudget = b.getAmount()
-                            // - wallet.getExpenseList().getMonthExpenses(b.getMonth(), b.getYear());
-
                             BigDecimal monthBudget = BigDecimal.valueOf(b.getAmount());
                             BigDecimal expenseSum = BigDecimal.valueOf(wallet.getExpenseList()
                                 .getMonthExpenses(b.getMonth(), b.getYear()));

--- a/src/main/java/wallet/logic/command/ViewCommand.java
+++ b/src/main/java/wallet/logic/command/ViewCommand.java
@@ -10,6 +10,7 @@ import wallet.model.record.Category;
 import wallet.model.record.Expense;
 import wallet.ui.Ui;
 
+import java.math.BigDecimal;
 import java.text.DateFormatSymbols;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -58,8 +59,14 @@ public class ViewCommand extends Command {
                                     + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
                             System.out.println("$" + b.getAmount());
 
-                            double remainingBudget = b.getAmount()
-                                    - wallet.getExpenseList().getMonthExpenses(b.getMonth(), b.getYear());
+                           // double remainingBudget = b.getAmount()
+                                   // - wallet.getExpenseList().getMonthExpenses(b.getMonth(), b.getYear());
+
+                            BigDecimal monthBudget = BigDecimal.valueOf(b.getAmount());
+                            BigDecimal expenseSum = BigDecimal.valueOf( wallet.getExpenseList()
+                                .getMonthExpenses(b.getMonth(), b.getYear()));
+                            double remainingBudget = monthBudget.subtract(expenseSum).doubleValue();
+
                             System.out.println(MESSAGE_REMAINING_BUDGET
                                     + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
                             System.out.println("$" + remainingBudget);
@@ -108,7 +115,7 @@ public class ViewCommand extends Command {
             ui.drawPieChart(expenseList);
             return false;
         } else {
-            System.out.println(MESSAGE_USAGE);
+            Ui.printError(MESSAGE_USAGE);
         }
         return false;
     }

--- a/src/main/java/wallet/logic/parser/AddCommandParser.java
+++ b/src/main/java/wallet/logic/parser/AddCommandParser.java
@@ -19,8 +19,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 
 public class AddCommandParser implements Parser<AddCommand> {
-    public static final String MESSAGE_ERROR_ADD_CONTACT = "Error in input format when adding contact.";
-    public static final String MESSAGE_ERROR_INSUFFICIENT_PARAMETERS = "There are insufficient parameters provided.";
+    public static final String MESSAGE_ERROR_ADD_CONTACT = "Error in command syntax when adding contact.";
     public static final String MESSAGE_ERROR_WRONG_DATETIME_FORMAT = "Wrong date format, use \"dd/MM/yyyy\".";
     public static final String MESSAGE_ERROR_INVALID_CATEGORY
             = "Category can only be Bills, Food, Others, Shopping or Transport.";
@@ -42,8 +41,6 @@ public class AddCommandParser implements Parser<AddCommand> {
             Expense expense;
             try {
                 expense = parseExpense(arguments[1]);
-            } catch (ArrayIndexOutOfBoundsException err) {
-                throw new InsufficientParameters(MESSAGE_ERROR_INSUFFICIENT_PARAMETERS);
             } catch (DateTimeParseException dt) {
                 throw new WrongDateTimeFormat(MESSAGE_ERROR_WRONG_DATETIME_FORMAT);
             }
@@ -55,11 +52,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         case "contact":
             Contact contact;
-            try {
-                contact = parseContact(arguments[1]);
-            } catch (ArrayIndexOutOfBoundsException err) {
-                throw new InsufficientParameters(MESSAGE_ERROR_INSUFFICIENT_PARAMETERS);
-            }
+            contact = parseContact(arguments[1]);
             if (contact != null) {
                 return new AddCommand(contact);
             } else {
@@ -69,8 +62,6 @@ public class AddCommandParser implements Parser<AddCommand> {
             Loan loan;
             try {
                 loan = parseLoan(arguments[1]);
-            } catch (ArrayIndexOutOfBoundsException err) {
-                throw new InsufficientParameters(MESSAGE_ERROR_INSUFFICIENT_PARAMETERS);
             } catch (DateTimeParseException dt) {
                 throw new WrongDateTimeFormat(MESSAGE_ERROR_WRONG_DATETIME_FORMAT);
             }
@@ -79,7 +70,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             }
             break;
         default:
-            System.out.println(AddCommand.MESSAGE_USAGE);
+            Ui.printError(AddCommand.MESSAGE_USAGE);
             return null;
         }
         return null;
@@ -193,7 +184,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         ContactParserHelper contactHelper = new ContactParserHelper();
         Contact contact = contactHelper.newInput(info);
         if (contact == null) {
-            System.out.println(MESSAGE_ERROR_ADD_CONTACT);
+            Ui.printError(MESSAGE_ERROR_ADD_CONTACT);
             return null;
         } else {
             return contact;

--- a/src/main/java/wallet/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/wallet/logic/parser/DeleteCommandParser.java
@@ -1,6 +1,5 @@
 package wallet.logic.parser;
 
-import wallet.exception.InsufficientParameters;
 import wallet.exception.WrongParameterFormat;
 import wallet.logic.command.DeleteCommand;
 import java.text.ParseException;
@@ -11,7 +10,6 @@ import java.text.ParseException;
  */
 public class DeleteCommandParser implements Parser<DeleteCommand> {
     public static final String MESSAGE_ERROR_INVALID_ID = "You need to provide a valid ID (Number) when deleting.";
-    public static final String MESSAGE_ERROR_MISSING_ID = "You need to provide an ID when deleting.";
 
     /**
      * Changes user input String to appropriate parameters
@@ -27,8 +25,6 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         int id = 0;
         try {
             id = Integer.parseInt(arguments[1]);
-        } catch (ArrayIndexOutOfBoundsException err) {
-            throw new InsufficientParameters(MESSAGE_ERROR_MISSING_ID);
         } catch (NumberFormatException err) {
             throw new WrongParameterFormat(MESSAGE_ERROR_INVALID_ID);
         }

--- a/src/main/java/wallet/logic/parser/EditCommandParser.java
+++ b/src/main/java/wallet/logic/parser/EditCommandParser.java
@@ -11,6 +11,7 @@ import wallet.model.record.Category;
 import wallet.model.record.Expense;
 import wallet.model.record.Loan;
 import wallet.model.record.RecurrenceRate;
+import wallet.ui.Ui;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -21,7 +22,7 @@ import java.time.format.DateTimeParseException;
  * change user input String into appropriate parameters.
  */
 public class EditCommandParser implements Parser<EditCommand> {
-    public static final String MESSAGE_ERROR_EDIT_CONTACT = "Error in input format when editing contact.";
+    public static final String MESSAGE_ERROR_EDIT_CONTACT = "Error in command syntax when editing contact.";
     public static final String MESSAGE_ERROR_NOT_NUMBER = "Error when parsing number, please provide proper input.";
     public static final String MESSAGE_ERROR_WRONG_DATE_FORMAT = "Error when parsing date, format is \"dd/MM/yyyy\".";
     public static final String MESSAGE_ERROR_INVALID_RECURRENCE_RATE = "Invalid value for rate of recurrence. "
@@ -35,8 +36,6 @@ public class EditCommandParser implements Parser<EditCommand> {
             Expense expense;
             try {
                 expense = parseExpense(arguments[1]);
-            } catch (ArrayIndexOutOfBoundsException err) {
-                throw new InsufficientParameters("There are no arguments when editing the expense!");
             } catch (NumberFormatException nf) {
                 throw new WrongParameterFormat(MESSAGE_ERROR_NOT_NUMBER);
             } catch (DateTimeParseException dt) {
@@ -50,11 +49,9 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         case "loan":
             Loan loan;
-            try {
-                loan = parseLoan(arguments[1]);
-            } catch (ArrayIndexOutOfBoundsException err) {
-                throw new InsufficientParameters("There are no arguments when editing the loan!");
-            }
+
+            loan = parseLoan(arguments[1]);
+
             if (loan != null) {
                 return new EditCommand(loan);
             }
@@ -62,11 +59,9 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         case "contact":
             Contact contact;
-            try {
-                contact = parseContact(arguments[1]);
-            } catch (ArrayIndexOutOfBoundsException err) {
-                throw new InsufficientParameters("There are no arguments when editing the contact!");
-            }
+
+            contact = parseContact(arguments[1]);
+
             if (contact != null) {
                 return new EditCommand(contact);
             } else {
@@ -74,7 +69,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             }
 
         default:
-            System.out.println(EditCommand.MESSAGE_USAGE);
+            Ui.printError(EditCommand.MESSAGE_USAGE);
             return null;
         }
         return null;
@@ -96,18 +91,18 @@ public class EditCommandParser implements Parser<EditCommand> {
                 ContactParserHelper contactHelper = new ContactParserHelper();
                 Contact contact = contactHelper.updateInput(parameters);
                 if (contact == null) {
-                    System.out.println(MESSAGE_ERROR_EDIT_CONTACT);
+                    Ui.printError(MESSAGE_ERROR_EDIT_CONTACT);
                     return null;
                 }
                 contact.setId(id);
                 return contact;
             } catch (NumberFormatException e) {
-                System.out.println(MESSAGE_ERROR_EDIT_CONTACT);
+                Ui.printError(MESSAGE_ERROR_EDIT_CONTACT);
                 return null;
             }
 
         }
-        System.out.println(MESSAGE_ERROR_EDIT_CONTACT);
+        Ui.printError(MESSAGE_ERROR_EDIT_CONTACT);
         return null;
         //@@author
 
@@ -225,12 +220,12 @@ public class EditCommandParser implements Parser<EditCommand> {
                     expense.setRecurring(false);
                     expense.setRecFrequency(rec);
                 } else {
-                    System.out.println(MESSAGE_ERROR_INVALID_RECURRENCE_RATE);
+                    Ui.printError(MESSAGE_ERROR_INVALID_RECURRENCE_RATE);
                     return null;
                 }
                 parameters = getRecurring[0].trim();
             } else {
-                System.out.println(EditCommand.MESSAGE_ERROR_FORMAT);
+                Ui.printError(EditCommand.MESSAGE_ERROR_FORMAT);
                 return null;
             }
         }
@@ -242,7 +237,7 @@ public class EditCommandParser implements Parser<EditCommand> {
                 expense.setDate(date);
                 parameters = getDate[0].trim();
             } else {
-                System.out.println(EditCommand.MESSAGE_ERROR_FORMAT);
+                Ui.printError(EditCommand.MESSAGE_ERROR_FORMAT);
                 return null;
             }
         }
@@ -252,7 +247,7 @@ public class EditCommandParser implements Parser<EditCommand> {
                 expense.setCategory(Category.getCategory(getCategory[1].trim()));
                 parameters = getCategory[0].trim();
             } else {
-                System.out.println(EditCommand.MESSAGE_ERROR_FORMAT);
+                Ui.printError(EditCommand.MESSAGE_ERROR_FORMAT);
                 return null;
             }
         }
@@ -262,7 +257,7 @@ public class EditCommandParser implements Parser<EditCommand> {
                 expense.setAmount(Double.parseDouble(getAmount[1].trim()));
                 parameters = getAmount[0].trim();
             } else {
-                System.out.println(EditCommand.MESSAGE_ERROR_FORMAT);
+                Ui.printError(EditCommand.MESSAGE_ERROR_FORMAT);
                 return null;
             }
         }

--- a/src/main/java/wallet/logic/parser/ExportCommandParser.java
+++ b/src/main/java/wallet/logic/parser/ExportCommandParser.java
@@ -9,6 +9,7 @@ import wallet.model.record.ExpenseList;
 import wallet.model.record.Budget;
 import wallet.model.record.Loan;
 import wallet.model.record.Category;
+import wallet.ui.Ui;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -19,7 +20,7 @@ import java.util.List;
 
 public class ExportCommandParser implements Parser<ExportCommand> {
 
-    public static final String MESSAGE_ERROR_WRONG_FORMAT = "Wrong Format for command input!";
+    public static final String MESSAGE_ERROR_WRONG_FORMAT = "Wrong export command syntax!";
     public static final String MESSAGE_ERROR_WRONG_YEARMONTH = "Wrong year and month input!";
     private double budgetLeft;
 
@@ -39,7 +40,7 @@ public class ExportCommandParser implements Parser<ExportCommand> {
             return new ExportCommand(data, arguments[0]);
         } else if ("expense".equals(arguments[0])) {
             if (arguments.length != 2) {
-                System.out.println(MESSAGE_ERROR_WRONG_FORMAT);
+                Ui.printError(MESSAGE_ERROR_WRONG_FORMAT);
                 return null;
             }
             List<String[]> data = parseExpense(arguments[1]);
@@ -50,7 +51,7 @@ public class ExportCommandParser implements Parser<ExportCommand> {
             }
         }
 
-        System.out.println(MESSAGE_ERROR_WRONG_FORMAT);
+        Ui.printError(MESSAGE_ERROR_WRONG_FORMAT);
         return null;
     }
 
@@ -97,12 +98,12 @@ public class ExportCommandParser implements Parser<ExportCommand> {
                     }
                 }
             } else {
-                System.out.println(MESSAGE_ERROR_WRONG_FORMAT);
+                Ui.printError(MESSAGE_ERROR_WRONG_FORMAT);
                 return null;
             }
 
         } catch (NumberFormatException | DateTimeException e) {
-            System.out.println(MESSAGE_ERROR_WRONG_YEARMONTH);
+            Ui.printError(MESSAGE_ERROR_WRONG_YEARMONTH);
             return null;
         }
 

--- a/src/main/java/wallet/logic/parser/ImportCommandParser.java
+++ b/src/main/java/wallet/logic/parser/ImportCommandParser.java
@@ -11,6 +11,7 @@ import wallet.model.record.ExpenseList;
 import wallet.model.record.Loan;
 import wallet.model.record.LoanList;
 import wallet.model.record.RecurrenceRate;
+import wallet.ui.Ui;
 
 import java.io.File;
 import java.io.FileReader;
@@ -23,8 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ImportCommandParser implements Parser<ImportCommand> {
-    public static final String MESSAGE_ERROR_WRONG_FORMAT = "Wrong Format input for import!";
-    public static final String MESSAGE_ERROR_READING_CSV = "Error in reading csv!";
+    public static final String MESSAGE_ERROR_WRONG_FORMAT = "Wrong import command syntax!";
+    public static final String MESSAGE_ERROR_READING_CSV = "Error in importing csv!";
     public static final String MESSAGE_ERROR_CSV_FORMAT = "CSV is formatted wrongly";
 
     /**
@@ -37,7 +38,7 @@ public class ImportCommandParser implements Parser<ImportCommand> {
     public ImportCommand parse(String input) {
         String[] arguments = input.split(" ", 2);
         if (arguments.length != 2) {
-            System.out.println(MESSAGE_ERROR_WRONG_FORMAT);
+            Ui.printError(MESSAGE_ERROR_WRONG_FORMAT);
             return null;
         }
         arguments[0] = arguments[0].toLowerCase();
@@ -61,7 +62,7 @@ public class ImportCommandParser implements Parser<ImportCommand> {
             }
         }
 
-        System.out.println(MESSAGE_ERROR_WRONG_FORMAT);
+        Ui.printError(MESSAGE_ERROR_WRONG_FORMAT);
         return null;
     }
 
@@ -97,7 +98,7 @@ public class ImportCommandParser implements Parser<ImportCommand> {
                 } else if (s[3].trim().equalsIgnoreCase("borrow")) {
                     isLend = false;
                 } else {
-                    System.out.println(MESSAGE_ERROR_CSV_FORMAT);
+                    Ui.printError(MESSAGE_ERROR_CSV_FORMAT);
                     return null;
                 }
 
@@ -106,12 +107,12 @@ public class ImportCommandParser implements Parser<ImportCommand> {
                 } else if (s[4].trim().equalsIgnoreCase("no")) {
                     isSettled = false;
                 } else {
-                    System.out.println(MESSAGE_ERROR_CSV_FORMAT);
+                    Ui.printError(MESSAGE_ERROR_CSV_FORMAT);
                     return null;
                 }
 
                 if (s[5].trim().isEmpty()) {
-                    System.out.println(MESSAGE_ERROR_CSV_FORMAT);
+                    Ui.printError(MESSAGE_ERROR_CSV_FORMAT);
                     return null;
                 } else {
                     name = s[5].trim();
@@ -143,10 +144,10 @@ public class ImportCommandParser implements Parser<ImportCommand> {
 
 
         } catch (URISyntaxException | IOException | NullPointerException e) {
-            System.out.println(MESSAGE_ERROR_READING_CSV);
+            Ui.printError(MESSAGE_ERROR_READING_CSV);
             return null;
         } catch (DateTimeParseException | NumberFormatException | ArrayIndexOutOfBoundsException e) {
-            System.out.println(MESSAGE_ERROR_CSV_FORMAT);
+            Ui.printError(MESSAGE_ERROR_CSV_FORMAT);
             return null;
         }
         return data;
@@ -177,7 +178,7 @@ public class ImportCommandParser implements Parser<ImportCommand> {
                 Category cat = Category.getCategory(s[3]);
 
                 if (cat == null) {
-                    System.out.println(MESSAGE_ERROR_CSV_FORMAT);
+                    Ui.printError(MESSAGE_ERROR_CSV_FORMAT);
                     return null;
                 }
                 boolean isRecurring = false;
@@ -187,7 +188,7 @@ public class ImportCommandParser implements Parser<ImportCommand> {
                     date = LocalDate.parse(s[1].trim(), formatter);
                     freq = RecurrenceRate.getRecurrence(s[5].trim());
                     if (freq == null) {
-                        System.out.println(MESSAGE_ERROR_CSV_FORMAT);
+                        Ui.printError(MESSAGE_ERROR_CSV_FORMAT);
                         return null;
                     }
                 }
@@ -198,10 +199,10 @@ public class ImportCommandParser implements Parser<ImportCommand> {
             filereader.close();
 
         } catch (URISyntaxException | IOException | NullPointerException e) {
-            System.out.println(MESSAGE_ERROR_READING_CSV);
+            Ui.printError(MESSAGE_ERROR_READING_CSV);
             return null;
         } catch (NumberFormatException | DateTimeParseException | ArrayIndexOutOfBoundsException e) {
-            System.out.println(MESSAGE_ERROR_CSV_FORMAT);
+            Ui.printError(MESSAGE_ERROR_CSV_FORMAT);
             return null;
         }
         return data;

--- a/src/main/java/wallet/logic/parser/ListCommandParser.java
+++ b/src/main/java/wallet/logic/parser/ListCommandParser.java
@@ -1,6 +1,7 @@
 package wallet.logic.parser;
 
 import wallet.logic.command.ListCommand;
+import wallet.ui.Ui;
 
 /**
  * The ListCommandParser class helps to
@@ -14,7 +15,7 @@ public class ListCommandParser implements Parser<ListCommand> {
             return new ListCommand(input);
         }
 
-        System.out.println(ListCommand.MESSAGE_USAGE);
+        Ui.printError(ListCommand.MESSAGE_USAGE);
         return null;
     }
 }

--- a/src/main/java/wallet/logic/parser/ParserManager.java
+++ b/src/main/java/wallet/logic/parser/ParserManager.java
@@ -28,7 +28,7 @@ import java.text.ParseException;
  */
 public class ParserManager {
 
-    private String parametersError = " command does not have parameters or have invalid parameters!";
+    private String parametersError = " command does not have parameters or have insufficient parameters!";
 
     /**
      * Parses the user input command and returns the corresponding Command object.

--- a/src/main/java/wallet/logic/parser/ReminderCommandParser.java
+++ b/src/main/java/wallet/logic/parser/ReminderCommandParser.java
@@ -3,6 +3,7 @@
 package wallet.logic.parser;
 
 import wallet.logic.command.ReminderCommand;
+import wallet.ui.Ui;
 
 /**
  * The RemindCommand class
@@ -16,7 +17,7 @@ public class ReminderCommandParser implements Parser<ReminderCommand> {
             return new ReminderCommand(input);
         }
 
-        System.out.println(ReminderCommand.MESSAGE_USAGE);
+        Ui.printError(ReminderCommand.MESSAGE_USAGE);
         return null;
     }
 }

--- a/src/main/java/wallet/logic/parser/SetBudgetParser.java
+++ b/src/main/java/wallet/logic/parser/SetBudgetParser.java
@@ -2,33 +2,27 @@
 
 package wallet.logic.parser;
 
-import wallet.exception.InsufficientParameters;
 import wallet.exception.WrongParameterFormat;
 import wallet.logic.command.SetBudgetCommand;
 import wallet.model.record.Budget;
 
-import java.text.ParseException;
-
 public class SetBudgetParser implements Parser<SetBudgetCommand> {
 
     @Override
-    public SetBudgetCommand parse(String input) throws ParseException, NumberFormatException {
+    public SetBudgetCommand parse(String input) throws NumberFormatException {
         String[] arguments = input.split(" ", 2);
         String[] amount = arguments[0].split("\\$", 2);
-        try {
-            Double budgetAmount = Double.parseDouble(amount[1].trim());
-            String[] monthYear = arguments[1].split("/", 2);
-            int month = Integer.parseInt(monthYear[0].trim());
-            int year = Integer.parseInt(monthYear[1].trim());
-            if (month < 0 || month > 12) {
-                throw new WrongParameterFormat("Nice try but month only runs for 1 to 12 :)");
-            } else if (year <= 0) {
-                throw  new WrongParameterFormat("I too wonder if zero or negative year exists...");
-            }
-            Budget budget = new Budget(budgetAmount, month, year);
-            return new SetBudgetCommand(budget);
-        } catch (ArrayIndexOutOfBoundsException err) {
-            throw new InsufficientParameters("Budget $<amount> <month/year>");
+
+        Double budgetAmount = Double.parseDouble(amount[1].trim());
+        String[] monthYear = arguments[1].split("/", 2);
+        int month = Integer.parseInt(monthYear[0].trim());
+        int year = Integer.parseInt(monthYear[1].trim());
+        if (month < 0 || month > 12) {
+            throw new WrongParameterFormat("Nice try but month only runs for 1 to 12 :)");
+        } else if (year <= 0) {
+            throw  new WrongParameterFormat("I too wonder if zero or negative year exists...");
         }
+        Budget budget = new Budget(budgetAmount, month, year);
+        return new SetBudgetCommand(budget);
     }
 }

--- a/src/main/java/wallet/thread/CurrencyThread.java
+++ b/src/main/java/wallet/thread/CurrencyThread.java
@@ -33,7 +33,6 @@ public class CurrencyThread implements Runnable {
             if (c.getCountry().toLowerCase().equals(givenCountry)) {
                 updateExpenseAndLoans(wallet, c);
                 System.out.println(CurrencyCommand.MESSAGE_SUCCESSFUL_CONVERSION + givenCountry);
-                System.out.println(CurrencyCommand.MESSAGE_ADDING_CURRENCY);
                 isExit = true;
             }
         }

--- a/src/test/java/wallet/logic/parser/SetBudgetParserTest.java
+++ b/src/test/java/wallet/logic/parser/SetBudgetParserTest.java
@@ -20,16 +20,12 @@ public class SetBudgetParserTest {
     public void parseBudgetValidInputSuccess() {
         SetBudgetParser setBudgetParser = new SetBudgetParser();
         String input = "$1000 01/2019";
-        try {
-            SetBudgetCommand setBudgetCommand = setBudgetParser.parse(input);
-            setBudgetCommand.execute(testWallet);
-            assertAll("Budget should contain these values",
-                () -> assertEquals(1000, testWallet.getBudgetList().getBudgetList().get(0).getAmount()),
-                () -> assertEquals(1, testWallet.getBudgetList().getBudgetList().get(0).getMonth()),
-                () -> assertEquals(2019, testWallet.getBudgetList().getBudgetList().get(0).getYear())
-            );
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
+        SetBudgetCommand setBudgetCommand = setBudgetParser.parse(input);
+        setBudgetCommand.execute(testWallet);
+        assertAll("Budget should contain these values",
+            () -> assertEquals(1000, testWallet.getBudgetList().getBudgetList().get(0).getAmount()),
+            () -> assertEquals(1, testWallet.getBudgetList().getBudgetList().get(0).getMonth()),
+            () -> assertEquals(2019, testWallet.getBudgetList().getBudgetList().get(0).getYear())
+        );
     }
 }


### PR DESCRIPTION
**Many Changes Made:**
1. At CurrencyCommand.java, removed "You can add or modify your own currency conversion in /currency.txt", since user cant modify the text file under resources folder.

2. Standardize printing of error messages with Ui.printError() in most of the files under logic folder.

3. Shifted most of the try-catch ArrayIndexOutOfBoundsException from Parser Files to ParserManager instead. Because at ParserManager, need to check for this exception too since the arguments after command_word can be empty. By default, the catch for this exception will be executed in ParserManager instead of the Parser Files, so no point putting arrayindexoutofbounds exception in the parser files. Error message at ParserManager updated to "command does not have parameters or have insufficient parameters".

4. Remove Updating of budget list at ImportCommand.java.

5. @matthewng1996 see if you want to use this following code for ViewCommand.java:
![image](https://user-images.githubusercontent.com/23446523/68542268-e86be280-03e5-11ea-8e82-2e4ea3e10425.png)

Because currently there is this issue of [repeating numbers](https://stackoverflow.com/questions/24180290/double-minus-operation-result) after subtraction:
<img width="211" alt="Capture" src="https://user-images.githubusercontent.com/23446523/68542318-6fb95600-03e6-11ea-9296-4acdf81d9e00.PNG">

After fixing will become:
<img width="211" alt="Capture2" src="https://user-images.githubusercontent.com/23446523/68542323-8364bc80-03e6-11ea-9c30-c71caa12c3d5.PNG">

6. Fixed an error at Setbudgetparsertest.java.

**Stuff that need to be done by team:**
1.  @kyang96  need to remove the updating of budget list at addcommand.java

2. Update EditCommandParser and AddCommandParser to handle non case sensitive command parameters for loan and expense. 