### PR TITLE
Fixed AddCommand not to save budget

### DIFF
--- a/src/main/java/wallet/logic/command/AddCommand.java
+++ b/src/main/java/wallet/logic/command/AddCommand.java
@@ -7,6 +7,7 @@ import wallet.model.record.Expense;
 import wallet.model.record.Loan;
 import wallet.ui.Ui;
 
+import java.math.BigDecimal;
 import java.text.DateFormatSymbols;
 import java.time.LocalDate;
 
@@ -24,7 +25,7 @@ public class AddCommand extends Command {
     public static final String MESSAGE_SUCCESS_ADD_CONTACT = "Got it. I've added this contact.";
     public static final String MESSAGE_SUCCESS_ADD_EXPENSE = "Got it. I've added this expense:";
     public static final String MESSAGE_SUCCESS_ADD_LOAN = "Got it. I've added this loan:";
-    public static final String MESSAGE_NEW_BUDGET = " is your new budget for ";
+    public static final String MESSAGE_NEW_REMAINING_BUDGET = " is your budget left for ";
     public static final String MESSAGE_EXCEED_BUDGET = "Your budget has exceeded!!";
     public static final String MESSAGE_REACH_BUDGET = "You have reached your budget!!";
 
@@ -72,14 +73,18 @@ public class AddCommand extends Command {
             LocalDate date = expense.getDate();
             for (Budget b : wallet.getBudgetList().getBudgetList()) {
                 if (b.getMonth() == date.getMonthValue() && b.getYear() == date.getYear()) {
-                    b.setAmount(b.getAmount() - expense.getAmount());
-                    wallet.getBudgetList().setModified(true);
-                    if (b.getAmount() < 0) {
+                    BigDecimal monthBudget = BigDecimal.valueOf(b.getAmount());
+                    BigDecimal expenseSum = BigDecimal.valueOf(wallet.getExpenseList()
+                            .getMonthExpenses(b.getMonth(), b.getYear()));
+                    double remainingBudget = monthBudget.subtract(expenseSum).doubleValue();
+                    remainingBudget += b.getAccountedExpenseAmount();
+                    b.setExpenseTakenIntoAccount(true);
+                    if (remainingBudget < 0) {
                         System.out.println(MESSAGE_EXCEED_BUDGET);
-                    } else if (b.getAmount() == 0) {
+                    } else if (remainingBudget == 0) {
                         System.out.println(MESSAGE_REACH_BUDGET);
                     }
-                    System.out.println("$" + b.getAmount() + MESSAGE_NEW_BUDGET
+                    System.out.println("$" + remainingBudget + MESSAGE_NEW_REMAINING_BUDGET
                             + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
                 }
             }

--- a/src/main/java/wallet/logic/command/GenerateCommand.java
+++ b/src/main/java/wallet/logic/command/GenerateCommand.java
@@ -90,7 +90,7 @@ public class GenerateCommand extends Command {
         wallet.getExpenseList().addExpense(expense10);
 
         //test data for budget
-        Budget budget1 = new Budget(1500.0, 10, 2019);
+        Budget budget1 = new Budget(1500.0, 10, 2019, true, 0);
 
         wallet.getBudgetList().addBudget(budget1);
 

--- a/src/main/java/wallet/logic/command/SetBudgetCommand.java
+++ b/src/main/java/wallet/logic/command/SetBudgetCommand.java
@@ -8,6 +8,7 @@ import wallet.model.record.BudgetList;
 import wallet.model.record.Expense;
 import wallet.ui.Ui;
 
+import java.math.BigDecimal;
 import java.text.DateFormatSymbols;
 import java.time.LocalDate;
 import java.util.Scanner;
@@ -17,7 +18,7 @@ import java.util.Scanner;
  */
 public class SetBudgetCommand extends Command {
     public static final String COMMAND_WORD = "budget";
-    public static final String MESSAGE_SET_BUDGET = " dollars is the budget set for ";
+    public static final String MESSAGE_SET_BUDGET = " dollars is a new budget set for ";
     public static final String MESSAGE_NOTE = "Note that to update your budget, "
             + "simply set the budget for the same month and year again.";
     public static final String MESSAGE_USAGE = "Error in format for command."
@@ -128,8 +129,11 @@ public class SetBudgetCommand extends Command {
         String reply = scanner.nextLine().toLowerCase();
         while (!"yes".equals(reply) || !"no".equals(reply)) {
             if ("yes".equals(reply)) {
-                double remainingBudget = budget.getAmount()
-                        - wallet.getExpenseList().getMonthExpenses(budget.getMonth(), budget.getYear());
+                BigDecimal monthBudget = BigDecimal.valueOf(budget.getAmount());
+                BigDecimal expenseSum = BigDecimal.valueOf(wallet.getExpenseList()
+                        .getMonthExpenses(budget.getMonth(), budget.getYear()));
+                double remainingBudget = monthBudget.subtract(expenseSum).doubleValue();
+                budget.setAmount(remainingBudget);
                 if (remainingBudget < 0) {
                     System.out.println(AddCommand.MESSAGE_EXCEED_BUDGET);
                     System.out.println(MESSAGE_CURRENT_BUDGET
@@ -157,6 +161,9 @@ public class SetBudgetCommand extends Command {
                 }
                 break;
             } else if ("no".equals(reply)) {
+                BigDecimal expenseSum = BigDecimal.valueOf(wallet.getExpenseList()
+                        .getMonthExpenses(budget.getMonth(), budget.getYear()));
+                budget.setAccountedExpenseAmount(expenseSum.doubleValue());
                 System.out.println(MESSAGE_CURRENT_BUDGET
                         + new DateFormatSymbols().getMonths()[budget.getMonth() - 1]
                         + " " + budget.getYear() + " is " + "$" + budget.getAmount());

--- a/src/main/java/wallet/logic/command/ViewCommand.java
+++ b/src/main/java/wallet/logic/command/ViewCommand.java
@@ -58,14 +58,20 @@ public class ViewCommand extends Command {
                                     + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
                             System.out.println("$" + b.getAmount());
 
-                            BigDecimal monthBudget = BigDecimal.valueOf(b.getAmount());
-                            BigDecimal expenseSum = BigDecimal.valueOf(wallet.getExpenseList()
-                                .getMonthExpenses(b.getMonth(), b.getYear()));
-                            double remainingBudget = monthBudget.subtract(expenseSum).doubleValue();
-
-                            System.out.println(MESSAGE_REMAINING_BUDGET
-                                + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
-                            System.out.println("$" + remainingBudget);
+                            if (b.getExpenseTakenIntoAccount()) {
+                                BigDecimal monthBudget = BigDecimal.valueOf(b.getAmount());
+                                BigDecimal expenseSum = BigDecimal.valueOf(wallet.getExpenseList()
+                                        .getMonthExpenses(b.getMonth(), b.getYear()));
+                                double remainingBudget = monthBudget.subtract(expenseSum).doubleValue();
+                                remainingBudget += b.getAccountedExpenseAmount();
+                                System.out.println(MESSAGE_REMAINING_BUDGET
+                                        + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
+                                System.out.println("$" + remainingBudget);
+                            } else {
+                                System.out.println(MESSAGE_REMAINING_BUDGET
+                                        + new DateFormatSymbols().getMonths()[b.getMonth() - 1] + " " + b.getYear());
+                                System.out.println("$" + b.getAmount());
+                            }
                             return false;
                         }
                     }

--- a/src/main/java/wallet/logic/parser/SetBudgetParser.java
+++ b/src/main/java/wallet/logic/parser/SetBudgetParser.java
@@ -22,7 +22,7 @@ public class SetBudgetParser implements Parser<SetBudgetCommand> {
         } else if (year <= 0) {
             throw  new WrongParameterFormat("I too wonder if zero or negative year exists...");
         }
-        Budget budget = new Budget(budgetAmount, month, year);
+        Budget budget = new Budget(budgetAmount, month, year, false, 0);
         return new SetBudgetCommand(budget);
     }
 }

--- a/src/main/java/wallet/model/record/Budget.java
+++ b/src/main/java/wallet/model/record/Budget.java
@@ -7,6 +7,8 @@ public class Budget {
     private double amount;
     private int month;
     private int year;
+    private boolean expenseTakenIntoAccount;
+    private double accountedExpenseAmount;
 
     /**
      * Constructs the Budget object.
@@ -14,10 +16,12 @@ public class Budget {
      * @param month month which budget is set to.
      * @param year year which budget is set to.
      */
-    public Budget(double amount, int month, int year) {
+    public Budget(double amount, int month, int year, boolean expenseTakenIntoAccount, double accountedExpenseAmount) {
         this.amount = amount;
         this.month = month;
         this.year = year;
+        this.expenseTakenIntoAccount = expenseTakenIntoAccount;
+        this.accountedExpenseAmount = accountedExpenseAmount;
     }
 
     /**
@@ -74,7 +78,42 @@ public class Budget {
         this.year = year;
     }
 
+    /**
+     * Gets the boolean value of whether the budget has taken existing expenses into account.
+     * @return boolean value of existing budget with existing expenses
+     */
+    public boolean getExpenseTakenIntoAccount() {
+        return expenseTakenIntoAccount;
+    }
+
+    /**
+     * Sets the boolean of the budget with exsiting expenses.
+     *
+     * @param expenseTakenIntoAccount The boolean value of budget with existing expenses accounted for.
+     */
+    public void setExpenseTakenIntoAccount(boolean expenseTakenIntoAccount) {
+        this.expenseTakenIntoAccount = expenseTakenIntoAccount;
+    }
+
+    /**
+     * Gets the amount of accounted expenses based on boolean value of Budget.
+     * @return accounted expenses amount to be added into existing budget
+     */
+    public double getAccountedExpenseAmount() {
+        return accountedExpenseAmount;
+    }
+
+    /**
+     * Sets the amount of accounted expenses.
+     *
+     * @param accountedExpenseAmount The accounted expenses amount to be added into existing budget
+     */
+    public void setAccountedExpenseAmount(double accountedExpenseAmount) {
+        this.accountedExpenseAmount = accountedExpenseAmount;
+    }
+
+
     public String writeToFile() {
-        return amount + "," + month + "," + year;
+        return amount + "," + month + "," + year + "," + expenseTakenIntoAccount + "," + accountedExpenseAmount;
     }
 }

--- a/src/main/java/wallet/storage/BudgetStorage.java
+++ b/src/main/java/wallet/storage/BudgetStorage.java
@@ -26,9 +26,11 @@ public class BudgetStorage extends Storage<Budget> {
             while (raf.getFilePointer() != raf.length()) {
                 str = raf.readLine();
                 String[] data = str.split(",");
-                if (!data[0].isEmpty() && !data[1].isEmpty() && !data[2].isEmpty()) {
+                if (!data[0].isEmpty() && !data[1].isEmpty() && !data[2].isEmpty()
+                        && !data[3].isEmpty() && !data[4].isEmpty()) {
                     Budget budget = new Budget(Double.parseDouble(data[0]),
-                            Integer.parseInt(data[1]), Integer.parseInt(data[2]));
+                            Integer.parseInt(data[1]), Integer.parseInt(data[2]),
+                            Boolean.parseBoolean(data[3]), Double.parseDouble(data[4]));
                     budgetList.add(budget);
                 }
             }

--- a/src/test/java/wallet/logic/command/SetBudgetTest.java
+++ b/src/test/java/wallet/logic/command/SetBudgetTest.java
@@ -33,7 +33,7 @@ public class SetBudgetTest {
 
         testWallet.getExpenseList().addExpense(new Expense("Lunch", localDate1, 3, Category.FOOD, false, null));
         testWallet.getExpenseList().addExpense(new Expense("Dinner", localDate2, 5, Category.FOOD, false, null));
-        testWallet.getBudgetList().addBudget(new Budget(100, 10, 2019));
+        testWallet.getBudgetList().addBudget(new Budget(100, 10, 2019, false, 0));
     }
 
     /**
@@ -41,7 +41,7 @@ public class SetBudgetTest {
      */
     @Test
     public void executeAddBudgetFail() {
-        Budget budget = new Budget(-10, 3, 2019);
+        Budget budget = new Budget(-10, 3, 2019, false, 0);
         SetBudgetCommand budgetCommand = new SetBudgetCommand(budget);
         budgetCommand.execute(testWallet);
         assertEquals(3, testWallet.getBudgetList().getBudgetList().size());
@@ -52,7 +52,7 @@ public class SetBudgetTest {
      */
     @Test
     public void executeAddBudgetSuccess() {
-        Budget budget = new Budget(50, 3, 2019);
+        Budget budget = new Budget(50, 3, 2019, false, 0);
         SetBudgetCommand budgetCommand = new SetBudgetCommand(budget);
         budgetCommand.execute(testWallet);
         assertEquals(3, testWallet.getBudgetList().getBudgetList().size());
@@ -63,7 +63,7 @@ public class SetBudgetTest {
      */
     @Test
     public void executeRemoveBudget() {
-        Budget budget = new Budget(0, 3, 2019);
+        Budget budget = new Budget(0, 3, 2019, false, 0);
         SetBudgetCommand budgetCommand = new SetBudgetCommand(budget);
         budgetCommand.execute(testWallet);
         assertEquals(1, testWallet.getBudgetList().getBudgetList().size());
@@ -75,7 +75,7 @@ public class SetBudgetTest {
      */
     @Test
     public void executeEditBudget() {
-        Budget budget = new Budget(150, 10, 2019);
+        Budget budget = new Budget(150, 10, 2019, false, 0);
         SetBudgetCommand budgetCommand = new SetBudgetCommand(budget);
         budgetCommand.execute(testWallet);
         assertEquals(150, budget.getAmount());
@@ -94,7 +94,7 @@ public class SetBudgetTest {
         addCommand.execute(testWallet);
         for (Budget b : testWallet.getBudgetList().getBudgetList()) {
             if (b.getMonth() == expense.getDate().getMonthValue() && b.getYear() == expense.getDate().getYear()) {
-                assertEquals(90, b.getAmount());
+                assertEquals(100, b.getAmount());
             }
         }
     }
@@ -104,7 +104,7 @@ public class SetBudgetTest {
      */
     @Test
     public void executeAddBudgetWithExistingExpensesWithUserInputYes() {
-        Budget budget = new Budget(100, 1, 2019);
+        Budget budget = new Budget(100, 1, 2019, false, 0);
         SetBudgetCommand budgetCommand = new SetBudgetCommand(budget);
 
         String input = "yes";
@@ -114,7 +114,7 @@ public class SetBudgetTest {
         double remainingBudget = budget.getAmount()
                 - testWallet.getExpenseList().getMonthExpenses(budget.getMonth(), budget.getYear());
         budgetCommand.execute(testWallet);
-        assertEquals(100, budget.getAmount());
+        assertEquals(97, budget.getAmount());
         assertEquals(97, remainingBudget);
     }
 
@@ -123,7 +123,7 @@ public class SetBudgetTest {
      */
     @Test
     public void executeAddBudgetWithExistingExpensesWithUserInputNo() {
-        Budget budget = new Budget(100, 1, 2019);
+        Budget budget = new Budget(100, 1, 2019, false, 0);
         SetBudgetCommand budgetCommand = new SetBudgetCommand(budget);
 
         String input = "no";

--- a/src/test/java/wallet/logic/command/ViewCommandTest.java
+++ b/src/test/java/wallet/logic/command/ViewCommandTest.java
@@ -25,7 +25,7 @@ public class ViewCommandTest {
      */
     @BeforeAll
     public static void setUp() {
-        testWallet.getBudgetList().addBudget(new Budget(1000, 10, 2019));
+        testWallet.getBudgetList().addBudget(new Budget(1000, 10, 2019, false, 0));
     }
 
     /**

--- a/src/test/java/wallet/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/wallet/logic/parser/ViewCommandParserTest.java
@@ -19,7 +19,7 @@ public class ViewCommandParserTest {
      */
     @BeforeAll
     public static void setUp() {
-        testWallet.getBudgetList().addBudget(new Budget(100, 10, 2019));
+        testWallet.getBudgetList().addBudget(new Budget(100, 10, 2019, false, 0));
     }
 
     /**


### PR DESCRIPTION
PLUS THIS:
Budget to take into account expenses that are accounted/not accounted for based on user's input

Previously: 
If there are existing expenses and user sets budget, user is given a choice to account for existing budget
If user replied "Yes", then budget amount that is set **AND SAVED** is (input budget amount - total existing expenses amount in that month)
If user replied "No", then budget amount that is set will remain intact. **HOWEVER**, when user add subsequent expenses, the previous expenses that should not be accounted for is deducted from the set budget - **THIS IS A BUG**

With this PR:
If user replied "No", all total amount of existing expenses that should not be accounted for is stored within the Budget, so when user adds subsequent budget, this stored amount is then added back to the budget to take into account of this existing budget that the user does not want to deduct in the first place.